### PR TITLE
Add pytest setup and expand test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,21 @@ All configurable settings are documented in `backend/.env.example`. The project 
 
 ### Running tests
 
-Use Django's test runner with the dedicated test settings module:
+#### Backend (pytest)
+
+Run the Python test suite from the repository root. The provided `pytest.ini` automatically configures the Django settings module and Python path.
 
 ```bash
-DJANGO_SETTINGS_MODULE=core.settings.test python backend/manage.py test
+pytest
+```
+
+#### Frontend (Flutter)
+
+Execute the Flutter widget and unit tests from the app directory:
+
+```bash
+cd frontend/flutter_app
+flutter test
 ```
 
 ## Frontend (Flutter) Setup

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,42 @@
+"""Shared pytest fixtures for the Django backend."""
+from __future__ import annotations
+
+import pytest
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def api_client() -> APIClient:
+    """Return a DRF API client for request testing."""
+    return APIClient()
+
+
+@pytest.fixture
+def health_check_url() -> str:
+    """Return the configured health check endpoint path."""
+    return settings.HEALTH_CHECK_PATH
+
+
+@pytest.fixture
+def user_factory(db):
+    """Factory for creating users with sensible defaults."""
+
+    def create_user(**kwargs):
+        password = kwargs.pop("password", "Passw0rd!")
+        email = kwargs.pop("email", "user@example.com")
+
+        user_model = get_user_model()
+        user = user_model.objects.create_user(email=email, password=password, **kwargs)
+        # Store the plain password for convenience in tests.
+        user.raw_password = password  # type: ignore[attr-defined]
+        return user
+
+    return create_user
+
+
+@pytest.fixture
+def user(user_factory):
+    """Create and return a default user instance."""
+    return user_factory()

--- a/backend/core/settings/test.py
+++ b/backend/core/settings/test.py
@@ -1,5 +1,34 @@
 """Test settings."""
 from .base import *  # noqa: F401,F403
 
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
 PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 CELERY_TASK_ALWAYS_EAGER = True
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels.layers.InMemoryChannelLayer",
+    }
+}
+
+MIGRATION_MODULES = {
+    "common": None,
+    "users": None,
+    "business": None,
+    "appointments": None,
+    "marketplace": None,
+    "services": None,
+    "payments": None,
+    "notifications": None,
+}
+
+MIDDLEWARE = [
+    middleware
+    for middleware in MIDDLEWARE
+    if middleware != "django_guid.middleware.GuidMiddleware"
+]

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,32 @@
+"""Authentication flow tests."""
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_jwt_auth_flow(api_client, user_factory):
+    password = "StrongPass123!"
+    user = user_factory(email="auth@example.com", password=password)
+
+    token_url = reverse("token_obtain_pair")
+    response = api_client.post(token_url, {"email": user.email, "password": password})
+
+    assert response.status_code == 200
+    tokens = response.json()
+    assert "access" in tokens and "refresh" in tokens
+
+    api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {tokens['access']}")
+    user_list_url = reverse("user-list")
+    list_response = api_client.get(user_list_url)
+
+    assert list_response.status_code == 200
+    payload = list_response.json()
+    assert any(item["email"] == user.email for item in payload)
+
+    refresh_url = reverse("token_refresh")
+    refresh_response = api_client.post(refresh_url, {"refresh": tokens["refresh"]})
+
+    assert refresh_response.status_code == 200
+    assert "access" in refresh_response.json()

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,12 @@
+"""Tests for the backend health check endpoint."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_health_endpoint_returns_ok(client, health_check_url):
+    response = client.get(health_check_url)
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -1,0 +1,30 @@
+"""Tests for the custom user model."""
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+
+
+@pytest.mark.django_db
+def test_user_string_representation(user):
+    assert str(user) == user.email
+
+
+@pytest.mark.django_db
+def test_create_superuser_flags():
+    user_model = get_user_model()
+    admin = user_model.objects.create_superuser(
+        email="admin@example.com",
+        password="SuperSecret123!",
+    )
+
+    assert admin.is_staff is True
+    assert admin.is_superuser is True
+
+
+@pytest.mark.django_db
+def test_create_user_requires_email():
+    user_model = get_user_model()
+
+    with pytest.raises(ValueError):
+        user_model.objects.create_user(email="", password="password")

--- a/frontend/flutter_app/test/app_router_test.dart
+++ b/frontend/flutter_app/test/app_router_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_app/app.dart';
+
+import 'helpers/hydrated_bloc.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('navigates between tabs without transition animations', (tester) async {
+    await runHydrated(() async {
+      await tester.pumpWidget(App());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Manage your appointments'), findsOneWidget);
+
+      await tester.tap(find.text('Products'));
+      await tester.pump();
+      expect(find.text('Browse available products'), findsOneWidget);
+
+      await tester.tap(find.text('Services'));
+      await tester.pump();
+      expect(find.text('Discover services'), findsOneWidget);
+    });
+  });
+
+  testWidgets('returns to initial route when reselecting the active tab', (tester) async {
+    await runHydrated(() async {
+      await tester.pumpWidget(App());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Products'));
+      await tester.pump();
+      expect(find.text('Browse available products'), findsOneWidget);
+
+      await tester.tap(find.text('Appointments'));
+      await tester.pump();
+      expect(find.text('Manage your appointments'), findsOneWidget);
+    });
+  });
+}

--- a/frontend/flutter_app/test/localization/app_localizations_test.dart
+++ b/frontend/flutter_app/test/localization/app_localizations_test.dart
@@ -1,0 +1,25 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_app/app.dart';
+
+import '../helpers/hydrated_bloc.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('renders localized strings based on active locale', (tester) async {
+    await runHydrated(() async {
+      tester.binding.platformDispatcher.localeTestValue = const Locale('fa');
+
+      await tester.pumpWidget(App());
+      await tester.pumpAndSettle();
+
+      expect(find.text('آپاتیه کدکس'), findsOneWidget);
+      expect(find.byTooltip('تغییر پوسته'), findsOneWidget);
+
+      tester.binding.platformDispatcher.clearLocaleTestValue();
+    });
+  });
+}

--- a/frontend/flutter_app/test/shared/widgets/app_navigation_bar_test.dart
+++ b/frontend/flutter_app/test/shared/widgets/app_navigation_bar_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_app/shared/widgets/app_navigation_bar.dart';
+
+Widget _buildWrappedNavigationBar({
+  int currentIndex = 0,
+  ValueChanged<int>? onItemSelected,
+  Locale? locale,
+}) {
+  return MaterialApp(
+    locale: locale,
+    localizationsDelegates: const [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: AppNavigationBar(
+        currentIndex: currentIndex,
+        onItemSelected: onItemSelected ?? (_) {},
+      ),
+    ),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('renders localized tab labels and handles selection', (tester) async {
+    var tappedIndex = -1;
+
+    await tester.pumpWidget(
+      _buildWrappedNavigationBar(
+        currentIndex: 1,
+        onItemSelected: (index) => tappedIndex = index,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final navigationBar = tester.widget<NavigationBar>(find.byType(NavigationBar));
+    expect(navigationBar.selectedIndex, 1);
+    expect(find.text('Products'), findsOneWidget);
+
+    await tester.tap(find.text('Services'));
+    await tester.pump();
+
+    expect(tappedIndex, 2);
+  });
+
+  testWidgets('applies localization for non-English locales', (tester) async {
+    await tester.pumpWidget(
+      _buildWrappedNavigationBar(
+        currentIndex: 0,
+        locale: const Locale('fa'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('نوبت‌دهی'), findsOneWidget);
+    expect(find.text('محصولات'), findsOneWidget);
+    expect(find.text('خدمات'), findsOneWidget);
+  });
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = core.settings.test
+pythonpath = backend
+addopts = -ra
+testpaths =
+    backend/tests
+    frontend
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ channels-redis>=4.1
 celery>=5.3
 redis>=5.0
 django-guid>=3.4
+pytest>=8.0
+pytest-django>=4.7


### PR DESCRIPTION
## Summary
- configure pytest-django with dedicated settings overrides and shared fixtures
- add backend tests for the health endpoint, JWT auth flow, and the custom user model
- add Flutter widget tests for navigation, routing transitions, and localization plus document new test commands

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4abf52db083209cf4a367b0b94503