### PR TITLE
Add pre-commit config and CI pipelines

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,53 @@
+name: Backend CI
+
+on:
+  push:
+    paths:
+      - '.github/workflows/backend.yml'
+      - 'backend/**'
+      - 'requirements.txt'
+      - 'pytest.ini'
+      - '.pre-commit-config.yaml'
+  pull_request:
+    paths:
+      - '.github/workflows/backend.yml'
+      - 'backend/**'
+      - 'requirements.txt'
+      - 'pytest.ini'
+      - '.pre-commit-config.yaml'
+
+jobs:
+  lint-and-test:
+    name: Lint & Test (Python)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pre-commit
+
+      - name: Run Python linters
+        run: |
+          pre-commit run --hook-stage manual --all-files black
+          pre-commit run --hook-stage manual --all-files isort
+          pre-commit run --hook-stage manual --all-files flake8
+          pre-commit run --hook-stage manual --all-files pylint
+          pre-commit run --hook-stage manual --all-files django-check-migrations
+
+      - name: Run pytest
+        env:
+          DJANGO_SETTINGS_MODULE: core.settings.test
+          PYTHONPATH: backend
+        run: pytest

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,52 @@
+name: Frontend CI
+
+on:
+  push:
+    paths:
+      - '.github/workflows/frontend.yml'
+      - 'frontend/**'
+  pull_request:
+    paths:
+      - '.github/workflows/frontend.yml'
+      - 'frontend/**'
+
+jobs:
+  flutter-ci:
+    name: Flutter format, analyze & test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.pub-cache
+            frontend/flutter_app/.dart_tool
+          key: ${{ runner.os }}-flutter-${{ hashFiles('frontend/flutter_app/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+
+      - name: Install dependencies
+        working-directory: frontend/flutter_app
+        run: flutter pub get
+
+      - name: Format check
+        working-directory: frontend/flutter_app
+        run: flutter format --set-exit-if-changed .
+
+      - name: Analyze
+        working-directory: frontend/flutter_app
+        run: flutter analyze
+
+      - name: Test
+        working-directory: frontend/flutter_app
+        run: flutter test

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,26 @@
+name: Infrastructure Checks
+
+on:
+  push:
+    paths:
+      - '.github/workflows/infra.yml'
+      - 'infra/**'
+  pull_request:
+    paths:
+      - '.github/workflows/infra.yml'
+      - 'infra/**'
+
+jobs:
+  docker-build:
+    name: docker compose build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build services
+        run: docker compose -f infra/docker-compose.yml build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,57 @@
+default_language_version:
+  python: python3.11
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        name: black (Python formatting)
+        types: [python]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (Python imports)
+        types: [python]
+        args: ["--profile=black"]
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        name: flake8 (Python lint)
+        types: [python]
+  - repo: https://github.com/PyCQA/pylint
+    rev: v3.1.0
+    hooks:
+      - id: pylint
+        name: pylint (Django aware)
+        types: [python]
+        args:
+          - --django-settings-module=core.settings.test
+          - --load-plugins=pylint_django
+        env:
+          DJANGO_SETTINGS_MODULE: core.settings.test
+          PYTHONPATH: backend
+        additional_dependencies:
+          - pylint-django==3.1.0
+  - repo: local
+    hooks:
+      - id: django-check-migrations
+        name: Django migrations up-to-date
+        entry: bash -c 'python backend/manage.py makemigrations --check --dry-run'
+        language: system
+        pass_filenames: false
+        stages: [commit, manual]
+      - id: flutter-format
+        name: Flutter format
+        entry: bash -c 'cd frontend/flutter_app && flutter format --set-exit-if-changed .'
+        language: system
+        files: ^frontend/flutter_app/.*\.(dart|ya?ml)$
+        pass_filenames: false
+      - id: flutter-analyze
+        name: Flutter analyze
+        entry: bash -c 'cd frontend/flutter_app && flutter analyze'
+        language: system
+        files: ^frontend/flutter_app/.*\.(dart|ya?ml)$
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Apatie Codex
 
+[![Backend CI](https://github.com/OWNER/Apatie-codex/actions/workflows/backend.yml/badge.svg)](https://github.com/OWNER/Apatie-codex/actions/workflows/backend.yml)
+[![Frontend CI](https://github.com/OWNER/Apatie-codex/actions/workflows/frontend.yml/badge.svg)](https://github.com/OWNER/Apatie-codex/actions/workflows/frontend.yml)
+[![Infrastructure Checks](https://github.com/OWNER/Apatie-codex/actions/workflows/infra.yml/badge.svg)](https://github.com/OWNER/Apatie-codex/actions/workflows/infra.yml)
+
+> Replace `OWNER` with the GitHub organisation or username that hosts this repository to render live status badges.
+
 ## Development Environment Bootstrap
 
 ### Docker Compose workflow
@@ -82,6 +88,23 @@ If you prefer running the backend without Docker:
    celery -A core.celery beat -l info
    python backend/manage.py runworker
    ```
+
+### Pre-commit hooks
+
+Automate formatting, linting, and migration checks with [pre-commit](https://pre-commit.com/). The configured hooks run Black,
+isort, Flake8, and Pylint for the Django backend, enforce `flutter format`/`flutter analyze` for the client, and ensure
+migrations are kept in sync:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+Run all hooks locally before pushing changes:
+
+```bash
+pre-commit run --all-files
+```
 
 ## Backend overview
 


### PR DESCRIPTION
## Summary
- add a shared pre-commit configuration that formats Python/Dart, runs linting, and checks Django migrations
- configure backend, frontend, and infrastructure GitHub Actions workflows with caching and targeted checks
- document the new automation with CI status badges and local pre-commit setup instructions

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4af6dbe3483209e9c4f18fb84c380