### PR TITLE
Add community templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Bug Report
+description: Report a reproducible problem in the project
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: Provide a concise summary of the issue.
+      placeholder: Short description of the problem
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Reproduction Steps
+      description: List the steps that consistently reproduce the issue.
+      placeholder: |
+        1. Go to...
+        2. Click on...
+        3. Observe...
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behaviour
+      description: Describe what you expected to happen instead.
+      placeholder: Describe the expected outcome
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual Behaviour
+      description: Explain what actually happened, including error messages.
+      placeholder: Describe the observed behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Add links or drag in any relevant screenshots.
+      placeholder: Attach or link to screenshots
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Define the conditions that must be met for the fix to be considered complete.
+      placeholder: List acceptance criteria
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Project Discussions
+    url: https://github.com/Apatie-codex/discussions
+    about: Please use the discussion forum for questions or general conversations.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Project Discussions
-    url: https://github.com/Apatie-codex/discussions
+    url: https://github.com/mehran-shabani/Apatie-codex/discussions
     about: Please use the discussion forum for questions or general conversations.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature Request
+description: Suggest an idea or enhancement for the project
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We appreciate your interest in improving the project!
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: Provide a concise summary of the request.
+      placeholder: Short description of the feature
+    validations:
+      required: true
+  - type: textarea
+    id: problem_statement
+    attributes:
+      label: Problem Statement
+      description: Describe the problem or opportunity this feature addresses.
+      placeholder: Explain the motivation behind the request
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed Solution
+      description: Describe your proposed solution or approach.
+      placeholder: Outline your idea or approach
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Add links or drag in any supporting visuals.
+      placeholder: Attach or link to screenshots or diagrams
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Define what success looks like for this request.
+      placeholder: List acceptance criteria
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+- 
+
+## Testing
+- 
+
+## Release Note
+- [ ] No release note required
+- [ ] Included in release notes
+- Notes:
+
+## Deployment Considerations
+- 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,10 @@
 ## Summary
 - 
 
+## Related Issues
+- Closes #issue_number (if applicable)
+- Relates to #issue_number (if applicable)
+
 ## Testing
 - 
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 ## Development Environment Bootstrap
 
+## Contributing
+
+We encourage contributors to review our [issue templates](.github/ISSUE_TEMPLATE/) and [pull request template](.github/pull_request_template.md) before opening a ticket or submitting code. Bug reports and feature proposals should include clear summaries, reproduction steps or problem statements, expected outcomes, relevant screenshots, and acceptance criteria to help maintainers respond quickly. Pull requests should document the change summary, testing evidence, release note impact, and any deployment considerations so reviewers can merge with confidence.
+
 ### Docker Compose workflow
 
 1. Copy the provided environment templates:


### PR DESCRIPTION
## Summary
- add bug report and feature request issue templates to capture key information
- disable blank issues and direct contributors to discussions when appropriate
- introduce a pull request template and advertise the contribution process in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecc773a074832083412b9a33638e41