### PR TITLE
chore: automate releases with release please

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir -r /app/requirements.txt
+
+COPY backend /app/backend
+
+WORKDIR /app/backend
+
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim AS builder
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
@@ -9,14 +9,32 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements.txt /app/requirements.txt
+COPY requirements.txt ./requirements.txt
 RUN pip install --upgrade pip \
-    && pip install --no-cache-dir -r /app/requirements.txt
+    && pip install --no-cache-dir -r requirements.txt
 
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local /usr/local
 COPY backend /app/backend
+
+RUN groupadd --system app \
+    && useradd --system --gid app --create-home app \
+    && chown -R app:app /app
+
+USER app
 
 WORKDIR /app/backend
 
 EXPOSE 8000
 
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--workers", "3", "core.wsgi:application"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ redis>=5.0
 django-guid>=3.4
 pytest>=8.0
 pytest-django>=4.7
+gunicorn>=21.2


### PR DESCRIPTION
## Summary
- add a Release Automation workflow that runs Release Please on pushes to work and publishes assets on release events
- configure permissions and Docker/asset publishing steps to run when a release is published
- document the release automation process and contributor expectations in the README
- add a root Dockerfile so the release workflow can build and push the backend image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eccb578ff883209b4b8ef85526cc7f