### PR TITLE
Align JWT signing key with production secret

### DIFF
--- a/backend/core/settings/prod.py
+++ b/backend/core/settings/prod.py
@@ -38,6 +38,10 @@ def _resolve_secret_key() -> str:
 
 SECRET_KEY = _resolve_secret_key()
 
+# Keep JWT signing key consistent with the resolved secret key to avoid
+# using the insecure development default when SECRET_KEY is regenerated.
+SIMPLE_JWT["SIGNING_KEY"] = SECRET_KEY
+
 
 DEFAULT_ALLOWED_HOSTS = ["apatie.example"]
 ALLOWED_HOSTS = ENV.list("ALLOWED_HOSTS", default=DEFAULT_ALLOWED_HOSTS)


### PR DESCRIPTION
## Summary
- synchronize SIMPLE_JWT signing key with the resolved production SECRET_KEY to avoid mismatched credentials

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68eceb6cf8448320be31d00d998b710c