### PR TITLE
Remove lint checks from CI workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   lint-and-test:
-    name: Lint & Test (Python)
+    name: Test (Python)
     runs-on: ubuntu-latest
 
     steps:
@@ -37,14 +37,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install pre-commit
-
-      - name: Run Python linters
-        run: |
-          pre-commit run --hook-stage manual --all-files black
-          pre-commit run --hook-stage manual --all-files isort
-          pre-commit run --hook-stage manual --all-files flake8
-          pre-commit run --hook-stage manual --all-files pylint
-          pre-commit run --hook-stage manual --all-files django-check-migrations
 
       - name: Run pytest
         env:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   flutter-ci:
-    name: Flutter format, analyze & test
+    name: Flutter tests
     runs-on: ubuntu-latest
 
     steps:
@@ -38,14 +38,6 @@ jobs:
       - name: Install dependencies
         working-directory: frontend/flutter_app
         run: flutter pub get
-
-      - name: Format check
-        working-directory: frontend/flutter_app
-        run: flutter format --set-exit-if-changed .
-
-      - name: Analyze
-        working-directory: frontend/flutter_app
-        run: flutter analyze
 
       - name: Test
         working-directory: frontend/flutter_app


### PR DESCRIPTION
## Summary
- drop the manual pre-commit lint step from the backend CI workflow
- remove the Flutter format and analyze checks from the frontend CI workflow
- retitle the affected jobs to reflect that they now only run tests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecec28812c8320b1ad57610851505c