### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pub"
+    directory: "/frontend/flutter_app"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- add Dependabot configuration covering GitHub Actions, backend Python (pip), and Flutter pub dependencies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ed2b1f53288320ac8585907be0269f