### PR TITLE
feat: add design system foundations

### DIFF
--- a/frontend/flutter_app/lib/design_system/foundations/colors.dart
+++ b/frontend/flutter_app/lib/design_system/foundations/colors.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+
+class AppColorPalette {
+  const AppColorPalette({
+    required this.colorScheme,
+    required this.success,
+    required this.onSuccess,
+    required this.successContainer,
+    required this.onSuccessContainer,
+    required this.warning,
+    required this.onWarning,
+    required this.warningContainer,
+    required this.onWarningContainer,
+    required this.info,
+    required this.onInfo,
+    required this.infoContainer,
+    required this.onInfoContainer,
+  });
+
+  final ColorScheme colorScheme;
+  final Color success;
+  final Color onSuccess;
+  final Color successContainer;
+  final Color onSuccessContainer;
+  final Color warning;
+  final Color onWarning;
+  final Color warningContainer;
+  final Color onWarningContainer;
+  final Color info;
+  final Color onInfo;
+  final Color infoContainer;
+  final Color onInfoContainer;
+}
+
+class AppColors {
+  const AppColors._();
+
+  static const AppColorPalette light = AppColorPalette(
+    colorScheme: ColorScheme(
+      brightness: Brightness.light,
+      primary: Color(0xFF0057B7),
+      onPrimary: Color(0xFFFFFFFF),
+      primaryContainer: Color(0xFFD5E3FF),
+      onPrimaryContainer: Color(0xFF001B3F),
+      secondary: Color(0xFF006D3C),
+      onSecondary: Color(0xFFFFFFFF),
+      secondaryContainer: Color(0xFFA6F2C5),
+      onSecondaryContainer: Color(0xFF00210F),
+      tertiary: Color(0xFF8A2C5B),
+      onTertiary: Color(0xFFFFFFFF),
+      tertiaryContainer: Color(0xFFFFD8E7),
+      onTertiaryContainer: Color(0xFF360018),
+      error: Color(0xFFB3261E),
+      onError: Color(0xFFFFFFFF),
+      errorContainer: Color(0xFFFFDAD6),
+      onErrorContainer: Color(0xFF410002),
+      background: Color(0xFFFBF8F5),
+      onBackground: Color(0xFF1B1B1F),
+      surface: Color(0xFFFBF8F5),
+      onSurface: Color(0xFF1B1B1F),
+      surfaceVariant: Color(0xFFE1E3ED),
+      onSurfaceVariant: Color(0xFF44474F),
+      outline: Color(0xFF74777F),
+      outlineVariant: Color(0xFFC5C6CF),
+      shadow: Color(0x26000000),
+      scrim: Color(0x66000000),
+      inverseSurface: Color(0xFF303033),
+      onInverseSurface: Color(0xFFF2F0F4),
+      inversePrimary: Color(0xFFA5C7FF),
+      surfaceTint: Color(0xFF0057B7),
+    ),
+    success: Color(0xFF1E7F4F),
+    onSuccess: Color(0xFFFFFFFF),
+    successContainer: Color(0xFFC6F7DA),
+    onSuccessContainer: Color(0xFF002112),
+    warning: Color(0xFFB25E00),
+    onWarning: Color(0xFFFFFFFF),
+    warningContainer: Color(0xFFFFDDB5),
+    onWarningContainer: Color(0xFF361900),
+    info: Color(0xFF005A9C),
+    onInfo: Color(0xFFFFFFFF),
+    infoContainer: Color(0xFFD2E4FF),
+    onInfoContainer: Color(0xFF001C38),
+  );
+
+  static const AppColorPalette dark = AppColorPalette(
+    colorScheme: ColorScheme(
+      brightness: Brightness.dark,
+      primary: Color(0xFFA5C7FF),
+      onPrimary: Color(0xFF002F67),
+      primaryContainer: Color(0xFF00458E),
+      onPrimaryContainer: Color(0xFFD5E3FF),
+      secondary: Color(0xFF8CD7AC),
+      onSecondary: Color(0xFF00391D),
+      secondaryContainer: Color(0xFF00522D),
+      onSecondaryContainer: Color(0xFFA6F2C5),
+      tertiary: Color(0xFFFFB1C9),
+      onTertiary: Color(0xFF530027),
+      tertiaryContainer: Color(0xFF75003B),
+      onTertiaryContainer: Color(0xFFFFD8E7),
+      error: Color(0xFFFFB4AB),
+      onError: Color(0xFF690005),
+      errorContainer: Color(0xFF93000A),
+      onErrorContainer: Color(0xFFFFDAD6),
+      background: Color(0xFF111417),
+      onBackground: Color(0xFFE2E2E6),
+      surface: Color(0xFF111417),
+      onSurface: Color(0xFFE2E2E6),
+      surfaceVariant: Color(0xFF44474F),
+      onSurfaceVariant: Color(0xFFC5C6CF),
+      outline: Color(0xFF8E9099),
+      outlineVariant: Color(0xFF44474F),
+      shadow: Color(0x99000000),
+      scrim: Color(0x99000000),
+      inverseSurface: Color(0xFFE2E2E6),
+      onInverseSurface: Color(0xFF1B1B1F),
+      inversePrimary: Color(0xFF0057B7),
+      surfaceTint: Color(0xFFA5C7FF),
+    ),
+    success: Color(0xFF6DD58C),
+    onSuccess: Color(0xFF00391E),
+    successContainer: Color(0xFF005230),
+    onSuccessContainer: Color(0xFFC6F7DA),
+    warning: Color(0xFFFFB760),
+    onWarning: Color(0xFF4F2600),
+    warningContainer: Color(0xFF713900),
+    onWarningContainer: Color(0xFFFFDDB5),
+    info: Color(0xFF78C7FF),
+    onInfo: Color(0xFF003152),
+    infoContainer: Color(0xFF004A78),
+    onInfoContainer: Color(0xFFD2E4FF),
+  );
+}

--- a/frontend/flutter_app/lib/design_system/foundations/radii.dart
+++ b/frontend/flutter_app/lib/design_system/foundations/radii.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/widgets.dart';
+
+class AppRadii {
+  const AppRadii._();
+
+  static const double none = 0;
+  static const double xs = 4;
+  static const double sm = 8;
+  static const double md = 12;
+  static const double lg = 16;
+  static const double xl = 24;
+  static const double pill = 999;
+
+  static const BorderRadius xsRadius = BorderRadius.all(Radius.circular(xs));
+  static const BorderRadius smRadius = BorderRadius.all(Radius.circular(sm));
+  static const BorderRadius mdRadius = BorderRadius.all(Radius.circular(md));
+  static const BorderRadius lgRadius = BorderRadius.all(Radius.circular(lg));
+  static const BorderRadius xlRadius = BorderRadius.all(Radius.circular(xl));
+  static const BorderRadius pillRadius = BorderRadius.all(Radius.circular(pill));
+}

--- a/frontend/flutter_app/lib/design_system/foundations/shadows.dart
+++ b/frontend/flutter_app/lib/design_system/foundations/shadows.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/widgets.dart';
+
+class AppShadowSet {
+  const AppShadowSet({
+    required this.level1,
+    required this.level2,
+    required this.level3,
+    required this.shadowColor,
+  });
+
+  final List<BoxShadow> level1;
+  final List<BoxShadow> level2;
+  final List<BoxShadow> level3;
+  final Color shadowColor;
+}
+
+class AppShadows {
+  const AppShadows._();
+
+  static const AppShadowSet light = AppShadowSet(
+    level1: <BoxShadow>[
+      BoxShadow(
+        color: Color(0x14000000),
+        blurRadius: 8,
+        offset: Offset(0, 2),
+        spreadRadius: 0,
+      ),
+    ],
+    level2: <BoxShadow>[
+      BoxShadow(
+        color: Color(0x1A000000),
+        blurRadius: 16,
+        offset: Offset(0, 6),
+        spreadRadius: -2,
+      ),
+    ],
+    level3: <BoxShadow>[
+      BoxShadow(
+        color: Color(0x20000000),
+        blurRadius: 24,
+        offset: Offset(0, 12),
+        spreadRadius: -4,
+      ),
+    ],
+    shadowColor: Color(0x26000000),
+  );
+
+  static const AppShadowSet dark = AppShadowSet(
+    level1: <BoxShadow>[
+      BoxShadow(
+        color: Color(0x33000000),
+        blurRadius: 8,
+        offset: Offset(0, 2),
+        spreadRadius: 0,
+      ),
+    ],
+    level2: <BoxShadow>[
+      BoxShadow(
+        color: Color(0x40000000),
+        blurRadius: 20,
+        offset: Offset(0, 8),
+        spreadRadius: -2,
+      ),
+    ],
+    level3: <BoxShadow>[
+      BoxShadow(
+        color: Color(0x4D000000),
+        blurRadius: 28,
+        offset: Offset(0, 16),
+        spreadRadius: -4,
+      ),
+    ],
+    shadowColor: Color(0x59000000),
+  );
+}

--- a/frontend/flutter_app/lib/design_system/foundations/spacing.dart
+++ b/frontend/flutter_app/lib/design_system/foundations/spacing.dart
@@ -1,0 +1,15 @@
+class AppSpacing {
+  const AppSpacing._();
+
+  static const double unit = 4.0;
+
+  static const double none = 0;
+  static const double xxs = unit;
+  static const double xs = unit * 2; // 8
+  static const double sm = unit * 3; // 12
+  static const double md = unit * 4; // 16
+  static const double lg = unit * 6; // 24
+  static const double xl = unit * 8; // 32
+  static const double xxl = unit * 10; // 40
+  static const double xxxl = unit * 12; // 48
+}

--- a/frontend/flutter_app/lib/design_system/foundations/touch_targets.dart
+++ b/frontend/flutter_app/lib/design_system/foundations/touch_targets.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/widgets.dart';
+
+import 'spacing.dart';
+
+class AppTouchTargets {
+  const AppTouchTargets._();
+
+  static const Size minimumSize = Size(48, 48);
+  static const double minimumHeight = 48;
+  static const double minInteractiveWidth = 48;
+  static const double comfortableHeight = 56;
+  static const double toolbarHeight = 64;
+  static const double denseToolbarHeight = 56;
+  static const double listTileHeight = 56;
+  static const double compactListTileHeight = 48;
+  static const EdgeInsets focusPadding = EdgeInsets.all(AppSpacing.xs);
+  static const EdgeInsets touchPadding = EdgeInsets.all(AppSpacing.xs);
+}

--- a/frontend/flutter_app/lib/design_system/foundations/typography.dart
+++ b/frontend/flutter_app/lib/design_system/foundations/typography.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+import 'colors.dart';
+
+class AppTypography {
+  const AppTypography._();
+
+  static const String _fontFamily = 'Vazirmatn';
+  static const List<String> _fontFamilyFallback = <String>['Roboto', 'Helvetica', 'Arial'];
+
+  static const TextStyle _headlineBase = TextStyle(
+    fontFamily: _fontFamily,
+    fontFamilyFallback: _fontFamilyFallback,
+    fontWeight: FontWeight.w700,
+    height: 1.25,
+    letterSpacing: -0.4,
+  );
+
+  static const TextStyle _titleBase = TextStyle(
+    fontFamily: _fontFamily,
+    fontFamilyFallback: _fontFamilyFallback,
+    fontWeight: FontWeight.w600,
+    height: 1.3,
+    letterSpacing: -0.2,
+  );
+
+  static const TextStyle _bodyBase = TextStyle(
+    fontFamily: _fontFamily,
+    fontFamilyFallback: _fontFamilyFallback,
+    fontWeight: FontWeight.w400,
+    height: 1.5,
+    letterSpacing: 0.05,
+  );
+
+  static const TextStyle _captionBase = TextStyle(
+    fontFamily: _fontFamily,
+    fontFamilyFallback: _fontFamilyFallback,
+    fontWeight: FontWeight.w400,
+    height: 1.4,
+    letterSpacing: 0.1,
+  );
+
+  static const TextStyle _labelBase = TextStyle(
+    fontFamily: _fontFamily,
+    fontFamilyFallback: _fontFamilyFallback,
+    fontWeight: FontWeight.w600,
+    height: 1.2,
+    letterSpacing: 0.2,
+  );
+
+  static TextTheme light(AppColorPalette palette) => _textTheme(
+        onSurface: palette.colorScheme.onSurface,
+        onSurfaceVariant: palette.colorScheme.onSurfaceVariant,
+        accent: palette.colorScheme.primary,
+      );
+
+  static TextTheme dark(AppColorPalette palette) => _textTheme(
+        onSurface: palette.colorScheme.onSurface,
+        onSurfaceVariant: palette.colorScheme.onSurfaceVariant,
+        accent: palette.colorScheme.primary,
+      );
+
+  static TextTheme _textTheme({
+    required Color onSurface,
+    required Color onSurfaceVariant,
+    required Color accent,
+  }) {
+    return TextTheme(
+      headlineLarge: _headlineBase.copyWith(fontSize: 32, color: onSurface),
+      headlineMedium: _headlineBase.copyWith(fontSize: 28, color: onSurface),
+      titleLarge: _titleBase.copyWith(fontSize: 22, color: onSurface),
+      titleMedium: _titleBase.copyWith(fontSize: 18, color: onSurfaceVariant),
+      bodyLarge: _bodyBase.copyWith(fontSize: 16, color: onSurface),
+      bodyMedium: _bodyBase.copyWith(fontSize: 14, color: onSurfaceVariant),
+      bodySmall: _captionBase.copyWith(fontSize: 12, color: onSurfaceVariant),
+      labelLarge: _labelBase.copyWith(fontSize: 16, color: accent),
+      labelMedium: _labelBase.copyWith(fontSize: 14, color: onSurface),
+      labelSmall: _captionBase.copyWith(fontSize: 11, color: onSurfaceVariant),
+    );
+  }
+}

--- a/frontend/flutter_app/lib/shared/theme/app_theme.dart
+++ b/frontend/flutter_app/lib/shared/theme/app_theme.dart
@@ -1,24 +1,441 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_app/design_system/foundations/colors.dart';
+import 'package:flutter_app/design_system/foundations/radii.dart';
+import 'package:flutter_app/design_system/foundations/shadows.dart';
+import 'package:flutter_app/design_system/foundations/spacing.dart';
+import 'package:flutter_app/design_system/foundations/touch_targets.dart';
+import 'package:flutter_app/design_system/foundations/typography.dart';
 
 class AppTheme {
   const AppTheme._();
 
   static ThemeData light() {
-    return ThemeData(
-      colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
-      useMaterial3: true,
-      brightness: Brightness.light,
+    const palette = AppColors.light;
+    final textTheme = AppTypography.light(palette);
+
+    return _buildTheme(
+      palette: palette,
+      textTheme: textTheme,
+      shadows: AppShadows.light,
     );
   }
 
   static ThemeData dark() {
+    const palette = AppColors.dark;
+    final textTheme = AppTypography.dark(palette);
+
+    return _buildTheme(
+      palette: palette,
+      textTheme: textTheme,
+      shadows: AppShadows.dark,
+    );
+  }
+
+  static ThemeData _buildTheme({
+    required AppColorPalette palette,
+    required TextTheme textTheme,
+    required AppShadowSet shadows,
+  }) {
+    final colorScheme = palette.colorScheme;
+
+    OutlineInputBorder outline(Color color, double width) {
+      return OutlineInputBorder(
+        borderRadius: AppRadii.mdRadius,
+        borderSide: BorderSide(color: color, width: width),
+      );
+    }
+
     return ThemeData(
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: Colors.indigo,
-        brightness: Brightness.dark,
-      ),
       useMaterial3: true,
-      brightness: Brightness.dark,
+      brightness: colorScheme.brightness,
+      colorScheme: colorScheme,
+      scaffoldBackgroundColor: colorScheme.background,
+      textTheme: textTheme,
+      iconTheme: IconThemeData(color: colorScheme.onSurfaceVariant),
+      appBarTheme: AppBarTheme(
+        backgroundColor: colorScheme.surface,
+        foregroundColor: colorScheme.onSurface,
+        elevation: 0,
+        shadowColor: shadows.shadowColor,
+        centerTitle: true,
+        toolbarHeight: AppTouchTargets.toolbarHeight,
+        titleTextStyle: textTheme.titleLarge,
+        surfaceTintColor: colorScheme.surfaceTint,
+      ),
+      cardTheme: CardTheme(
+        elevation: 0,
+        margin: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.lg,
+          vertical: AppSpacing.md,
+        ),
+        shape: const RoundedRectangleBorder(
+          borderRadius: AppRadii.lgRadius,
+        ),
+        shadowColor: shadows.shadowColor,
+        clipBehavior: Clip.antiAlias,
+        color: colorScheme.surface,
+        surfaceTintColor: colorScheme.surfaceTint,
+      ),
+      dialogTheme: DialogTheme(
+        backgroundColor: colorScheme.surface,
+        surfaceTintColor: colorScheme.surfaceTint,
+        titleTextStyle: textTheme.titleLarge,
+        contentTextStyle: textTheme.bodyMedium,
+        shape: const RoundedRectangleBorder(borderRadius: AppRadii.lgRadius),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ButtonStyle(
+          minimumSize: MaterialStateProperty.all(AppTouchTargets.minimumSize),
+          padding: MaterialStateProperty.all(
+            const EdgeInsets.symmetric(
+              horizontal: AppSpacing.lg,
+              vertical: AppSpacing.sm,
+            ),
+          ),
+          shape: MaterialStateProperty.all(
+            const RoundedRectangleBorder(borderRadius: AppRadii.mdRadius),
+          ),
+          elevation: MaterialStateProperty.resolveWith<double?>((states) {
+            if (states.contains(MaterialState.disabled) ||
+                states.contains(MaterialState.pressed)) {
+              return 0;
+            }
+            return 1;
+          }),
+          backgroundColor: MaterialStateProperty.resolveWith<Color?>((states) {
+            if (states.contains(MaterialState.disabled)) {
+              return colorScheme.onSurface.withOpacity(0.12);
+            }
+            return colorScheme.primary;
+          }),
+          foregroundColor: MaterialStateProperty.resolveWith<Color?>((states) {
+            if (states.contains(MaterialState.disabled)) {
+              return colorScheme.onSurface.withOpacity(0.38);
+            }
+            return colorScheme.onPrimary;
+          }),
+          textStyle: MaterialStateProperty.all(textTheme.labelLarge),
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: ButtonStyle(
+          minimumSize: MaterialStateProperty.all(AppTouchTargets.minimumSize),
+          padding: MaterialStateProperty.all(
+            const EdgeInsets.symmetric(
+              horizontal: AppSpacing.lg,
+              vertical: AppSpacing.sm,
+            ),
+          ),
+          foregroundColor: MaterialStateProperty.resolveWith<Color?>((states) {
+            if (states.contains(MaterialState.disabled)) {
+              return colorScheme.onSurface.withOpacity(0.38);
+            }
+            return colorScheme.primary;
+          }),
+          overlayColor: MaterialStateProperty.resolveWith<Color?>((states) {
+            if (states.contains(MaterialState.pressed)) {
+              return colorScheme.primary.withOpacity(0.12);
+            }
+            return null;
+          }),
+          textStyle: MaterialStateProperty.all(textTheme.labelLarge),
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: ButtonStyle(
+          minimumSize: MaterialStateProperty.all(AppTouchTargets.minimumSize),
+          padding: MaterialStateProperty.all(
+            const EdgeInsets.symmetric(
+              horizontal: AppSpacing.lg,
+              vertical: AppSpacing.sm,
+            ),
+          ),
+          shape: MaterialStateProperty.all(
+            const RoundedRectangleBorder(borderRadius: AppRadii.mdRadius),
+          ),
+          side: MaterialStateProperty.resolveWith<BorderSide?>((states) {
+            if (states.contains(MaterialState.disabled)) {
+              return BorderSide(color: colorScheme.onSurface.withOpacity(0.12));
+            }
+            return BorderSide(color: colorScheme.outline);
+          }),
+          foregroundColor: MaterialStateProperty.resolveWith<Color?>((states) {
+            if (states.contains(MaterialState.disabled)) {
+              return colorScheme.onSurface.withOpacity(0.38);
+            }
+            return colorScheme.primary;
+          }),
+          overlayColor: MaterialStateProperty.resolveWith<Color?>((states) {
+            if (states.contains(MaterialState.pressed)) {
+              return colorScheme.primary.withOpacity(0.12);
+            }
+            return null;
+          }),
+          textStyle: MaterialStateProperty.all(textTheme.labelLarge),
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: colorScheme.surface,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.lg,
+          vertical: AppSpacing.sm,
+        ),
+        border: outline(colorScheme.outlineVariant, 1),
+        enabledBorder: outline(colorScheme.outlineVariant, 1),
+        focusedBorder: outline(colorScheme.primary, 2),
+        errorBorder: outline(colorScheme.error, 1.5),
+        focusedErrorBorder: outline(colorScheme.error, 2),
+        labelStyle: textTheme.bodyMedium,
+        helperStyle: textTheme.bodySmall,
+        errorStyle: textTheme.bodySmall?.copyWith(color: colorScheme.error),
+      ),
+      chipTheme: ChipThemeData(
+        backgroundColor: colorScheme.surface,
+        disabledColor: colorScheme.onSurface.withOpacity(0.12),
+        selectedColor: colorScheme.primary.withOpacity(0.12),
+        secondarySelectedColor: colorScheme.primary,
+        showCheckmark: false,
+        labelStyle: textTheme.bodyMedium!,
+        secondaryLabelStyle: textTheme.bodyMedium!.copyWith(
+          color: colorScheme.onPrimary,
+        ),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: AppSpacing.xs,
+        ),
+        shape: const RoundedRectangleBorder(
+          borderRadius: AppRadii.mdRadius,
+        ),
+      ),
+      listTileTheme: ListTileThemeData(
+        dense: false,
+        tileColor: colorScheme.surface,
+        textColor: colorScheme.onSurface,
+        iconColor: colorScheme.onSurfaceVariant,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.lg,
+          vertical: AppSpacing.xs,
+        ),
+        minLeadingWidth: AppTouchTargets.minInteractiveWidth,
+        shape: const RoundedRectangleBorder(
+          borderRadius: AppRadii.mdRadius,
+        ),
+      ),
+      dividerTheme: DividerThemeData(
+        color: colorScheme.outlineVariant,
+        thickness: 1,
+        space: AppSpacing.md,
+      ),
+      floatingActionButtonTheme: FloatingActionButtonThemeData(
+        backgroundColor: colorScheme.primary,
+        foregroundColor: colorScheme.onPrimary,
+        elevation: 3,
+        shape: const RoundedRectangleBorder(borderRadius: AppRadii.pillRadius),
+      ),
+      navigationBarTheme: NavigationBarThemeData(
+        height: AppTouchTargets.toolbarHeight,
+        backgroundColor: colorScheme.surface,
+        indicatorColor: colorScheme.primary.withOpacity(0.12),
+        surfaceTintColor: colorScheme.surfaceTint,
+        labelTextStyle: MaterialStateProperty.all(textTheme.labelMedium),
+      ),
+      bottomAppBarTheme: BottomAppBarTheme(
+        color: colorScheme.surface,
+        elevation: 0,
+        surfaceTintColor: colorScheme.surfaceTint,
+        height: AppTouchTargets.denseToolbarHeight,
+      ),
+      snackBarTheme: SnackBarThemeData(
+        backgroundColor: colorScheme.inverseSurface,
+        contentTextStyle: textTheme.bodyMedium?.copyWith(
+          color: colorScheme.onInverseSurface,
+        ),
+        behavior: SnackBarBehavior.floating,
+        shape: const RoundedRectangleBorder(borderRadius: AppRadii.lgRadius),
+        elevation: 4,
+      ),
+      checkboxTheme: CheckboxThemeData(
+        fillColor: MaterialStateProperty.resolveWith<Color?>((states) {
+          if (states.contains(MaterialState.disabled)) {
+            return colorScheme.onSurface.withOpacity(0.12);
+          }
+          if (states.contains(MaterialState.selected)) {
+            return colorScheme.primary;
+          }
+          return colorScheme.surface;
+        }),
+        checkColor: MaterialStateProperty.all(colorScheme.onPrimary),
+        side: BorderSide(color: colorScheme.outlineVariant),
+        shape: const RoundedRectangleBorder(borderRadius: AppRadii.smRadius),
+      ),
+      radioTheme: RadioThemeData(
+        fillColor: MaterialStateProperty.resolveWith<Color?>((states) {
+          if (states.contains(MaterialState.disabled)) {
+            return colorScheme.onSurface.withOpacity(0.12);
+          }
+          if (states.contains(MaterialState.selected)) {
+            return colorScheme.primary;
+          }
+          return colorScheme.outlineVariant;
+        }),
+      ),
+      switchTheme: SwitchThemeData(
+        thumbColor: MaterialStateProperty.resolveWith<Color?>((states) {
+          if (states.contains(MaterialState.disabled)) {
+            return colorScheme.onSurface.withOpacity(0.12);
+          }
+          if (states.contains(MaterialState.selected)) {
+            return colorScheme.primary;
+          }
+          return colorScheme.outlineVariant;
+        }),
+        trackColor: MaterialStateProperty.resolveWith<Color?>((states) {
+          if (states.contains(MaterialState.disabled)) {
+            return colorScheme.onSurface.withOpacity(0.1);
+          }
+          if (states.contains(MaterialState.selected)) {
+            return colorScheme.primary.withOpacity(0.3);
+          }
+          return colorScheme.outlineVariant.withOpacity(0.3);
+        }),
+      ),
+      progressIndicatorTheme: ProgressIndicatorThemeData(
+        color: colorScheme.primary,
+        linearTrackColor: colorScheme.surfaceVariant,
+        refreshBackgroundColor: colorScheme.surface,
+      ),
+      tooltipTheme: TooltipThemeData(
+        decoration: BoxDecoration(
+          color: colorScheme.inverseSurface,
+          borderRadius: AppRadii.smRadius,
+          boxShadow: shadows.level2,
+        ),
+        textStyle: textTheme.bodySmall?.copyWith(
+          color: colorScheme.onInverseSurface,
+        ),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: AppSpacing.xs,
+        ),
+      ),
+      bannerTheme: MaterialBannerThemeData(
+        backgroundColor: palette.infoContainer,
+        contentTextStyle: textTheme.bodyMedium?.copyWith(
+          color: palette.onInfoContainer,
+        ),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.lg,
+          vertical: AppSpacing.md,
+        ),
+      ),
+      extensions: <ThemeExtension<dynamic>>[
+        _AppSemanticStatusColors(
+          success: palette.success,
+          onSuccess: palette.onSuccess,
+          successContainer: palette.successContainer,
+          onSuccessContainer: palette.onSuccessContainer,
+          warning: palette.warning,
+          onWarning: palette.onWarning,
+          warningContainer: palette.warningContainer,
+          onWarningContainer: palette.onWarningContainer,
+          info: palette.info,
+          onInfo: palette.onInfo,
+          infoContainer: palette.infoContainer,
+          onInfoContainer: palette.onInfoContainer,
+        ),
+      ],
+    );
+  }
+}
+
+class _AppSemanticStatusColors extends ThemeExtension<_AppSemanticStatusColors> {
+  const _AppSemanticStatusColors({
+    required this.success,
+    required this.onSuccess,
+    required this.successContainer,
+    required this.onSuccessContainer,
+    required this.warning,
+    required this.onWarning,
+    required this.warningContainer,
+    required this.onWarningContainer,
+    required this.info,
+    required this.onInfo,
+    required this.infoContainer,
+    required this.onInfoContainer,
+  });
+
+  final Color success;
+  final Color onSuccess;
+  final Color successContainer;
+  final Color onSuccessContainer;
+  final Color warning;
+  final Color onWarning;
+  final Color warningContainer;
+  final Color onWarningContainer;
+  final Color info;
+  final Color onInfo;
+  final Color infoContainer;
+  final Color onInfoContainer;
+
+  @override
+  ThemeExtension<_AppSemanticStatusColors> copyWith({
+    Color? success,
+    Color? onSuccess,
+    Color? successContainer,
+    Color? onSuccessContainer,
+    Color? warning,
+    Color? onWarning,
+    Color? warningContainer,
+    Color? onWarningContainer,
+    Color? info,
+    Color? onInfo,
+    Color? infoContainer,
+    Color? onInfoContainer,
+  }) {
+    return _AppSemanticStatusColors(
+      success: success ?? this.success,
+      onSuccess: onSuccess ?? this.onSuccess,
+      successContainer: successContainer ?? this.successContainer,
+      onSuccessContainer: onSuccessContainer ?? this.onSuccessContainer,
+      warning: warning ?? this.warning,
+      onWarning: onWarning ?? this.onWarning,
+      warningContainer: warningContainer ?? this.warningContainer,
+      onWarningContainer: onWarningContainer ?? this.onWarningContainer,
+      info: info ?? this.info,
+      onInfo: onInfo ?? this.onInfo,
+      infoContainer: infoContainer ?? this.infoContainer,
+      onInfoContainer: onInfoContainer ?? this.onInfoContainer,
+    );
+  }
+
+  @override
+  ThemeExtension<_AppSemanticStatusColors> lerp(
+    covariant ThemeExtension<_AppSemanticStatusColors>? other,
+    double t,
+  ) {
+    if (other is! _AppSemanticStatusColors) {
+      return this;
+    }
+
+    return _AppSemanticStatusColors(
+      success: Color.lerp(success, other.success, t)!,
+      onSuccess: Color.lerp(onSuccess, other.onSuccess, t)!,
+      successContainer:
+          Color.lerp(successContainer, other.successContainer, t)!,
+      onSuccessContainer:
+          Color.lerp(onSuccessContainer, other.onSuccessContainer, t)!,
+      warning: Color.lerp(warning, other.warning, t)!,
+      onWarning: Color.lerp(onWarning, other.onWarning, t)!,
+      warningContainer:
+          Color.lerp(warningContainer, other.warningContainer, t)!,
+      onWarningContainer:
+          Color.lerp(onWarningContainer, other.onWarningContainer, t)!,
+      info: Color.lerp(info, other.info, t)!,
+      onInfo: Color.lerp(onInfo, other.onInfo, t)!,
+      infoContainer: Color.lerp(infoContainer, other.infoContainer, t)!,
+      onInfoContainer:
+          Color.lerp(onInfoContainer, other.onInfoContainer, t)!,
     );
   }
 }

--- a/frontend/flutter_app/lib/shared/theme/theme_cubit.dart
+++ b/frontend/flutter_app/lib/shared/theme/theme_cubit.dart
@@ -4,7 +4,10 @@ import 'package:hydrated_bloc/hydrated_bloc.dart';
 class ThemeCubit extends HydratedCubit<ThemeMode> {
   ThemeCubit() : super(ThemeMode.system);
 
-  void updateTheme(ThemeMode mode) => emit(mode);
+  void updateTheme(ThemeMode mode) {
+    if (state == mode) return;
+    emit(mode);
+  }
 
   void toggleTheme() {
     switch (state) {
@@ -18,6 +21,15 @@ class ThemeCubit extends HydratedCubit<ThemeMode> {
         emit(ThemeMode.system);
         break;
     }
+  }
+
+  ThemeMode effectiveTheme(Brightness platformBrightness) {
+    if (state == ThemeMode.system) {
+      return platformBrightness == Brightness.dark
+          ? ThemeMode.dark
+          : ThemeMode.light;
+    }
+    return state;
   }
 
   @override


### PR DESCRIPTION
## Summary
- introduce foundation tokens for colors, typography, spacing, radii, shadows, and touch targets to cover light and dark design palettes
- rebuild the Flutter app theme to compose Material components from the new tokens and expose semantic status colors
- update the theme cubit to avoid redundant state writes and resolve a concrete brightness when needed

## Testing
- not run (flutter CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68ed2ed233108320ac62dcdc32a1423a