### PR TITLE
Add pattern showcases and connect feature routes

### DIFF
--- a/frontend/flutter_app/lib/app_router.dart
+++ b/frontend/flutter_app/lib/app_router.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:go_router/go_router.dart';
 
+import 'modules/appointments/ui/patterns/full_screen_flow/appointments_full_screen_flow.dart';
 import 'modules/appointments/ui/screens/appointments_page.dart';
+import 'modules/marketplace/ui/patterns/dialog_card/marketplace_dialog_card_pattern.dart';
+import 'modules/marketplace/ui/patterns/horizontal_card_bar/marketplace_horizontal_card_bar.dart';
 import 'modules/marketplace/ui/screens/marketplace_page.dart';
+import 'modules/services/ui/patterns/floating_window/services_floating_window_pattern.dart';
 import 'modules/services/ui/screens/services_page.dart';
 import 'shared/layout/app_shell.dart';
 
@@ -23,6 +27,15 @@ class AppRouter {
                 pageBuilder: (context, state) => const NoTransitionPage(
                   child: AppointmentsPage(),
                 ),
+                routes: [
+                  GoRoute(
+                    path: AppointmentsFullScreenFlowPage.routePath,
+                    name: AppointmentsFullScreenFlowPage.routeName,
+                    pageBuilder: (context, state) => const NoTransitionPage(
+                      child: AppointmentsFullScreenFlowPage(),
+                    ),
+                  ),
+                ],
               ),
             ],
           ),
@@ -33,6 +46,22 @@ class AppRouter {
                 pageBuilder: (context, state) => const NoTransitionPage(
                   child: MarketplacePage(),
                 ),
+                routes: [
+                  GoRoute(
+                    path: MarketplaceHorizontalCardBarPage.routePath,
+                    name: MarketplaceHorizontalCardBarPage.routeName,
+                    pageBuilder: (context, state) => const NoTransitionPage(
+                      child: MarketplaceHorizontalCardBarPage(),
+                    ),
+                  ),
+                  GoRoute(
+                    path: MarketplaceDialogCardPatternPage.routePath,
+                    name: MarketplaceDialogCardPatternPage.routeName,
+                    pageBuilder: (context, state) => const NoTransitionPage(
+                      child: MarketplaceDialogCardPatternPage(),
+                    ),
+                  ),
+                ],
               ),
             ],
           ),
@@ -43,6 +72,15 @@ class AppRouter {
                 pageBuilder: (context, state) => const NoTransitionPage(
                   child: ServicesPage(),
                 ),
+                routes: [
+                  GoRoute(
+                    path: ServicesFloatingWindowPatternPage.routePath,
+                    name: ServicesFloatingWindowPatternPage.routeName,
+                    pageBuilder: (context, state) => const NoTransitionPage(
+                      child: ServicesFloatingWindowPatternPage(),
+                    ),
+                  ),
+                ],
               ),
             ],
           ),

--- a/frontend/flutter_app/lib/modules/appointments/ui/patterns/full_screen_flow/appointments_full_screen_flow.dart
+++ b/frontend/flutter_app/lib/modules/appointments/ui/patterns/full_screen_flow/appointments_full_screen_flow.dart
@@ -1,0 +1,361 @@
+import 'package:flutter/material.dart';
+import 'package:apatie/design_system/components/app_button.dart';
+import 'package:apatie/design_system/components/app_card.dart';
+import 'package:apatie/design_system/components/app_input_field.dart';
+import 'package:apatie/design_system/components/app_list.dart';
+import 'package:apatie/design_system/components/app_progress_indicator.dart';
+import 'package:apatie/design_system/foundations/radii.dart';
+import 'package:apatie/design_system/foundations/spacing.dart';
+
+class AppointmentsFullScreenFlow extends StatefulWidget {
+  const AppointmentsFullScreenFlow({super.key});
+
+  @override
+  State<AppointmentsFullScreenFlow> createState() =>
+      _AppointmentsFullScreenFlowState();
+}
+
+class _AppointmentsFullScreenFlowState
+    extends State<AppointmentsFullScreenFlow> {
+  int _currentStep = 0;
+  String? _selectedService;
+  String? _selectedExpert;
+  String? _selectedSlot;
+  final TextEditingController _searchController = TextEditingController();
+
+  final List<String> _services = const [
+    'مشاورهٔ تغذیهٔ تخصصی',
+    'برنامهٔ ورزشی شخصی‌سازی‌شده',
+    'پیگیری دورهٔ سلامت قلب',
+  ];
+
+  final List<String> _experts = const [
+    'دکتر الهام ساجدی – متخصص تغذیه',
+    'دکتر میلاد برومند – متخصص قلب',
+    'دکتر نازنین رفیعی – فیزیولوژیست ورزشی',
+  ];
+
+  final List<String> _timeSlots = const [
+    'سه‌شنبه ۲۵ مرداد، ساعت ۱۰:۳۰',
+    'چهارشنبه ۲۶ مرداد، ساعت ۱۴:۱۵',
+    'پنجشنبه ۲۷ مرداد، ساعت ۰۹:۰۰',
+  ];
+
+  void _goNext() {
+    if (_currentStep < 2) {
+      setState(() => _currentStep += 1);
+    }
+  }
+
+  void _goBack() {
+    if (_currentStep > 0) {
+      setState(() => _currentStep -= 1);
+    }
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Widget _buildStepContent(BuildContext context) {
+    switch (_currentStep) {
+      case 0:
+        return _SelectionStep(
+          title: 'مرحلهٔ نخست: انتخاب خدمت موردنظر',
+          description:
+              'با جست‌وجو و گزینش دقیق، خدمت مناسب را برای مراجعهٔ خود تعیین کنید.',
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              AppInputField(
+                label: 'جست‌وجوی خدمات',
+                controller: _searchController,
+                placeholder: 'عنوان یا کلیدواژهٔ خدمت را وارد کنید',
+                helperText:
+                    'نتایج پیشنهادی مطابق با دستورالعمل‌های رسمی نمایش داده می‌شود.',
+              ),
+              const SizedBox(height: AppSpacing.md),
+              Expanded(
+                child: AppCard(
+                  header: Text(
+                    'خدمات پیشنهادی',
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleMedium
+                        ?.copyWith(fontWeight: FontWeight.w600),
+                  ),
+                  child: AppList(
+                    items: _services
+                        .map(
+                          (service) => AppListItem(
+                            title: service,
+                            selected: _selectedService == service,
+                            onTap: () => setState(() => _selectedService = service),
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      case 1:
+        return _SelectionStep(
+          title: 'مرحلهٔ دوم: انتخاب متخصص معتمد',
+          description:
+              'کارشناس هماهنگ‌کنندهٔ مناسب را با مرور گزینه‌های رسمی برگزینید.',
+          child: AppCard(
+            header: Text(
+              'فهرست متخصصان پیشنهادی',
+              style: Theme.of(context)
+                  .textTheme
+                  .titleMedium
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            child: AppList(
+              items: _experts
+                  .map(
+                    (expert) => AppListItem(
+                      title: expert,
+                      selected: _selectedExpert == expert,
+                      onTap: () => setState(() => _selectedExpert = expert),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ),
+        );
+      default:
+        return _SelectionStep(
+          title: 'مرحلهٔ نهایی: تأیید زمان مراجعه',
+          description:
+              'زمان پیشنهادی را بررسی کنید تا نوبت به‌صورت رسمی ثبت گردد.',
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: AppCard(
+                  header: Text(
+                    'زمان‌بندی‌های آزاد',
+                    style: Theme.of(context)
+                        .textTheme
+                        .titleMedium
+                        ?.copyWith(fontWeight: FontWeight.w600),
+                  ),
+                  child: AppList(
+                    items: _timeSlots
+                        .map(
+                          (slot) => AppListItem(
+                            title: slot,
+                            selected: _selectedSlot == slot,
+                            onTap: () => setState(() => _selectedSlot = slot),
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ),
+              ),
+              const SizedBox(height: AppSpacing.md),
+              AppCard(
+                header: Text(
+                  'خلاصهٔ درخواست',
+                  style: Theme.of(context)
+                      .textTheme
+                      .titleMedium
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _SummaryRow(
+                      label: 'خدمت انتخاب‌شده',
+                      value: _selectedService ?? 'هنوز انتخاب نشده است',
+                    ),
+                    const SizedBox(height: AppSpacing.sm),
+                    _SummaryRow(
+                      label: 'متخصص پیشنهادی',
+                      value: _selectedExpert ?? 'هنوز انتخاب نشده است',
+                    ),
+                    const SizedBox(height: AppSpacing.sm),
+                    _SummaryRow(
+                      label: 'زمان مراجعه',
+                      value: _selectedSlot ?? 'هنوز تعیین نشده است',
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final totalSteps = 3;
+    final stepValue = (_currentStep + 1) / totalSteps;
+
+    return FocusTraversalGroup(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              borderRadius: AppRadii.lgRadius,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'رزرو مرحله‌به‌مرحلهٔ نوبت رسمی',
+                  style: Theme.of(context)
+                      .textTheme
+                      .headlineSmall
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  'فرم چندگام با رعایت محدودیت کنش‌های اصلی و بدون پیمایش تو‌در‌تو طراحی شده است.',
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                const SizedBox(height: AppSpacing.md),
+                AppProgressIndicator(
+                  value: stepValue,
+                  description:
+                      'مرحلهٔ ${_currentStep + 1} از $totalSteps با الزام پیام‌های فارسی رسمی',
+                ),
+                const SizedBox(height: AppSpacing.lg),
+                Expanded(
+                  child: AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 300),
+                    transitionBuilder: (child, animation) => FadeTransition(
+                      opacity: animation,
+                      child: child,
+                    ),
+                    child: _buildStepContent(context),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.lg),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    if (_currentStep > 0) ...[
+                      AppButton(
+                        label: 'بازگشت',
+                        onPressed: _goBack,
+                      ),
+                      const SizedBox(width: AppSpacing.sm),
+                    ],
+                    AppButton(
+                      label: _currentStep == 2 ? 'ثبت نهایی نوبت' : 'ادامه',
+                      onPressed: _goNext,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _SelectionStep extends StatelessWidget {
+  const _SelectionStep({
+    required this.title,
+    required this.description,
+    required this.child,
+  });
+
+  final String title;
+  final String description;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          title,
+          style: Theme.of(context)
+              .textTheme
+              .titleLarge
+              ?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Text(
+          description,
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        const SizedBox(height: AppSpacing.md),
+        Expanded(child: child),
+      ],
+    );
+  }
+}
+
+class _SummaryRow extends StatelessWidget {
+  const _SummaryRow({
+    required this.label,
+    required this.value,
+  });
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          flex: 2,
+          child: Text(
+            label,
+            style: Theme.of(context)
+                .textTheme
+                .bodyMedium
+                ?.copyWith(fontWeight: FontWeight.w600),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.md),
+        Expanded(
+          flex: 3,
+          child: Text(
+            value,
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class AppointmentsFullScreenFlowPage extends StatelessWidget {
+  const AppointmentsFullScreenFlowPage({super.key});
+
+  static const String routeName = 'appointmentsFullScreenFlow';
+  static const String routePath = 'full-screen-flow';
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: const [
+            Expanded(child: AppointmentsFullScreenFlow()),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/flutter_app/lib/modules/appointments/ui/screens/appointments_page.dart
+++ b/frontend/flutter_app/lib/modules/appointments/ui/screens/appointments_page.dart
@@ -1,5 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:apatie/design_system/components/app_button.dart';
+import 'package:apatie/design_system/foundations/spacing.dart';
 import 'package:apatie/l10n/app_localizations.dart';
+import 'package:apatie/modules/appointments/ui/patterns/full_screen_flow/appointments_full_screen_flow.dart';
+import 'package:apatie/modules/services/ui/patterns/floating_window/services_floating_window_pattern.dart';
+import 'package:apatie/modules/services/ui/screens/services_page.dart';
 
 class AppointmentsPage extends StatelessWidget {
   const AppointmentsPage({super.key});
@@ -11,11 +17,56 @@ class AppointmentsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context);
 
-    return Center(
-      child: Text(
-        localizations.appointmentsHeadline,
-        style: Theme.of(context).textTheme.headlineMedium,
-        textAlign: TextAlign.center,
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              localizations.appointmentsHeadline,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineSmall
+                  ?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'برای رزرو رسمی نوبت، فرم چندگام زیر با پیام‌های فارسی و حداقل دو کنش اصلی طراحی شده است.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 420, maxHeight: 620),
+              child: const AppointmentsFullScreenFlow(),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Align(
+              alignment: AlignmentDirectional.centerEnd,
+              child: AppButton(
+                label: 'مشاهدهٔ نسخهٔ تمام‌صفحه',
+                onPressed: () => context.push(
+                  '${AppointmentsPage.routePath}/${AppointmentsFullScreenFlowPage.routePath}',
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xl),
+            Text(
+              'پس از ثبت نوبت می‌توانید از پایش زنده برای کنترل وضعیت استفاده کنید.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Align(
+              alignment: AlignmentDirectional.centerStart,
+              child: AppButton(
+                label: 'نمایش پایش زندهٔ خدمات',
+                onPressed: () => context.go(
+                  '${ServicesPage.routePath}/${ServicesFloatingWindowPatternPage.routePath}',
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/frontend/flutter_app/lib/modules/marketplace/ui/patterns/dialog_card/marketplace_dialog_card_pattern.dart
+++ b/frontend/flutter_app/lib/modules/marketplace/ui/patterns/dialog_card/marketplace_dialog_card_pattern.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:apatie/design_system/components/app_button.dart';
+import 'package:apatie/design_system/components/app_card.dart';
+import 'package:apatie/design_system/components/app_component_states.dart';
+import 'package:apatie/design_system/components/app_dialog.dart';
+import 'package:apatie/design_system/components/app_label.dart';
+import 'package:apatie/design_system/foundations/spacing.dart';
+
+class MarketplaceDialogCardPattern extends StatelessWidget {
+  const MarketplaceDialogCardPattern({super.key});
+
+  Future<void> _showDetails(BuildContext context) async {
+    final theme = Theme.of(context);
+
+    await AppDialog.show(
+      context: context,
+      title: 'جزئیات رسمی خدمت انتخاب‌شده',
+      semanticLabel: 'گفت‌وگوی رسمی برای بررسی کارت خدمت',
+      content: AppCard(
+        compact: true,
+        tone: AppComponentStatus.info,
+        header: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'جلسهٔ ارزیابی جامع سلامت',
+              style: theme.textTheme.titleMedium
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            AppLabel(
+              text: 'گزارش رسمی ظرف ۲۴ ساعت ارسال می‌شود',
+              tone: AppComponentStatus.info,
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'کارت اطلاعاتی شامل مراحل آماده‌سازی، مدارک موردنیاز و مدت‌زمان تقریبی اجرای خدمت است. '
+              'تمام پیام‌ها به‌صورت فارسی رسمی نگاشته شده‌اند تا ابهامی ایجاد نشود.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'شرح مزایا:',
+              style: theme.textTheme.titleSmall
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+            Text(
+              '• هماهنگی هوشمند با متخصصان موردتأیید \n'
+              '• امکان دریافت مشاورهٔ تکمیلی پس از جلسه \n'
+              '• تضمین بازپرداخت در صورت لغو رسمی',
+              style: theme.textTheme.bodyMedium,
+            ),
+          ],
+        ),
+        footer: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            AppButton(
+              label: 'افزودن به مقایسه',
+              compact: true,
+              onPressed: () => Navigator.of(context).pop('compare'),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            AppButton(
+              label: 'تأیید انتخاب',
+              compact: true,
+              tone: AppComponentStatus.success,
+              onPressed: () => Navigator.of(context).pop('confirm'),
+            ),
+          ],
+        ),
+      ),
+      actions: const <Widget>[],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'بررسی چند گزینه در قالب گفت‌وگو',
+          style:
+              theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        Text(
+          'کارت اطلاعاتی داخل گفت‌وگو امکان مرور دقیق و تصمیم‌گیری رسمی را فراهم می‌کند.',
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AppButton(
+          label: 'مشاهدهٔ کارت در گفت‌وگو',
+          onPressed: () => _showDetails(context),
+        ),
+      ],
+    );
+  }
+}
+
+class MarketplaceDialogCardPatternPage extends StatelessWidget {
+  const MarketplaceDialogCardPatternPage({super.key});
+
+  static const String routeName = 'marketplaceDialogCard';
+  static const String routePath = 'dialog-card';
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: const MarketplaceDialogCardPattern(),
+      ),
+    );
+  }
+}

--- a/frontend/flutter_app/lib/modules/marketplace/ui/patterns/horizontal_card_bar/marketplace_horizontal_card_bar.dart
+++ b/frontend/flutter_app/lib/modules/marketplace/ui/patterns/horizontal_card_bar/marketplace_horizontal_card_bar.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:apatie/design_system/components/app_button.dart';
+import 'package:apatie/design_system/components/app_card.dart';
+import 'package:apatie/design_system/components/app_component_states.dart';
+import 'package:apatie/design_system/components/app_input_field.dart';
+import 'package:apatie/design_system/components/app_label.dart';
+import 'package:apatie/design_system/components/app_progress_indicator.dart';
+import 'package:apatie/design_system/foundations/spacing.dart';
+
+class MarketplaceHorizontalCardBar extends StatefulWidget {
+  const MarketplaceHorizontalCardBar({super.key});
+
+  @override
+  State<MarketplaceHorizontalCardBar> createState() =>
+      _MarketplaceHorizontalCardBarState();
+}
+
+class _MarketplaceHorizontalCardBarState
+    extends State<MarketplaceHorizontalCardBar> {
+  final TextEditingController _searchController = TextEditingController();
+  int _highlightedIndex = 0;
+
+  final List<_MarketplacePackage> _packages = const [
+    _MarketplacePackage(
+      title: 'پکیج غربالگری قلب و عروق',
+      description:
+          'شامل ارزیابی نوار قلب، آزمایش خون و مشاورهٔ تخصصی با گزارش رسمی.',
+      status: 'ظرفیت امروز محدود است',
+      price: '۲٬۹۵۰٬۰۰۰ ریال',
+    ),
+    _MarketplacePackage(
+      title: 'برنامهٔ تغذیهٔ شخصی',
+      description:
+          'تنظیم برنامهٔ سه‌مرحله‌ای با پایش دوره‌ای توسط متخصص ارشد.',
+      status: 'پیشنهاد ویژهٔ هفته',
+      price: '۱٬۷۵۰٬۰۰۰ ریال',
+    ),
+    _MarketplacePackage(
+      title: 'جلسهٔ تمرین تنفسی آنلاین',
+      description:
+          'دورهٔ ۴۵ دقیقه‌ای با مربی معتبر و ارائهٔ دستورالعمل کتبی.',
+      status: 'ظرفیت آزاد',
+      price: '۹۸۰٬۰۰۰ ریال',
+    ),
+  ];
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _handleHighlight(int index) {
+    setState(() => _highlightedIndex = index);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Semantics(
+      container: true,
+      label: 'نوار افقی کارت‌ها برای جست‌وجو و گزینش رسمی',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'جست‌وجو و گزینش خدمت مناسب',
+            style: theme.textTheme.titleLarge
+                ?.copyWith(fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            'با استفاده از نوار افقی کارت‌ها می‌توانید پیشنهادها را مرور و گزینهٔ مناسب را انتخاب کنید.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: AppSpacing.md),
+          AppInputField(
+            label: 'عبارت جست‌وجو',
+            controller: _searchController,
+            placeholder: 'مثال: برنامهٔ تغذیه یا پایش قلب',
+            helperText:
+                'حداکثر دو کنش اصلی در هر کارت فعال است و پیمایش تو‌در‌تو وجود ندارد.',
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          SizedBox(
+            height: 280,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+              itemBuilder: (context, index) {
+                final package = _packages[index];
+                final selected = _highlightedIndex == index;
+                return SizedBox(
+                  width: 320,
+                  child: AppCard(
+                    semanticLabel: 'گزینهٔ ${package.title}',
+                    tone:
+                        selected ? AppComponentStatus.success : AppComponentStatus.neutral,
+                    header: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          package.title,
+                          style: theme.textTheme.titleMedium
+                              ?.copyWith(fontWeight: FontWeight.w600),
+                        ),
+                        const SizedBox(height: AppSpacing.xs),
+                        AppLabel(
+                          text: package.status,
+                          tone: selected
+                              ? AppComponentStatus.success
+                              : AppComponentStatus.info,
+                          semanticLabel: 'وضعیت پیشنهاد: ${package.status}',
+                        ),
+                      ],
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          package.description,
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                        const SizedBox(height: AppSpacing.md),
+                        Text(
+                          'هزینهٔ نهایی: ${package.price}',
+                          style: theme.textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: AppSpacing.md),
+                        AppProgressIndicator(
+                          value: selected ? 0.9 : 0.6,
+                          description: selected
+                              ? 'پس از انتخاب می‌توانید سفارش را نهایی کنید.'
+                              : 'برای مقایسهٔ دقیق گزینه‌ها را مرور کنید.',
+                          compact: true,
+                        ),
+                      ],
+                    ),
+                    footer: Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        AppButton(
+                          label: 'افزودن به بررسی',
+                          onPressed: () => _handleHighlight(index),
+                          compact: true,
+                        ),
+                        const SizedBox(width: AppSpacing.sm),
+                        AppButton(
+                          label: 'انتخاب فوری',
+                          onPressed: () => _handleHighlight(index),
+                          tone: AppComponentStatus.success,
+                          compact: true,
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+              separatorBuilder: (context, index) => const SizedBox(width: AppSpacing.md),
+              itemCount: _packages.length,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MarketplacePackage {
+  const _MarketplacePackage({
+    required this.title,
+    required this.description,
+    required this.status,
+    required this.price,
+  });
+
+  final String title;
+  final String description;
+  final String status;
+  final String price;
+}
+
+class MarketplaceHorizontalCardBarPage extends StatelessWidget {
+  const MarketplaceHorizontalCardBarPage({super.key});
+
+  static const String routeName = 'marketplaceHorizontalCardBar';
+  static const String routePath = 'horizontal-card-bar';
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: const MarketplaceHorizontalCardBar(),
+      ),
+    );
+  }
+}

--- a/frontend/flutter_app/lib/modules/marketplace/ui/screens/marketplace_page.dart
+++ b/frontend/flutter_app/lib/modules/marketplace/ui/screens/marketplace_page.dart
@@ -1,5 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:apatie/design_system/components/app_button.dart';
+import 'package:apatie/design_system/foundations/spacing.dart';
 import 'package:apatie/l10n/app_localizations.dart';
+import 'package:apatie/modules/marketplace/ui/patterns/dialog_card/marketplace_dialog_card_pattern.dart';
+import 'package:apatie/modules/marketplace/ui/patterns/horizontal_card_bar/marketplace_horizontal_card_bar.dart';
 
 class MarketplacePage extends StatelessWidget {
   const MarketplacePage({super.key});
@@ -11,11 +16,50 @@ class MarketplacePage extends StatelessWidget {
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context);
 
-    return Center(
-      child: Text(
-        localizations.marketplaceHeadline,
-        style: Theme.of(context).textTheme.headlineMedium,
-        textAlign: TextAlign.center,
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              localizations.marketplaceHeadline,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineSmall
+                  ?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'جست‌وجو و گزینش خدمات باید با پیام‌های رسمی، بدون پیمایش تو‌در‌تو و با حداکثر دو کنش اصلی انجام شود.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AppSpacing.xl),
+            const MarketplaceHorizontalCardBar(),
+            const SizedBox(height: AppSpacing.md),
+            Align(
+              alignment: AlignmentDirectional.centerEnd,
+              child: AppButton(
+                label: 'نمایش نوار کارت‌ها در مسیر مستقل',
+                onPressed: () => context.push(
+                  '${MarketplacePage.routePath}/${MarketplaceHorizontalCardBarPage.routePath}',
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xl),
+            const MarketplaceDialogCardPattern(),
+            const SizedBox(height: AppSpacing.md),
+            Align(
+              alignment: AlignmentDirectional.centerEnd,
+              child: AppButton(
+                label: 'باز کردن نمونهٔ گفت‌وگو',
+                onPressed: () => context.push(
+                  '${MarketplacePage.routePath}/${MarketplaceDialogCardPatternPage.routePath}',
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/frontend/flutter_app/lib/modules/services/ui/patterns/floating_window/services_floating_window_pattern.dart
+++ b/frontend/flutter_app/lib/modules/services/ui/patterns/floating_window/services_floating_window_pattern.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+import 'package:apatie/design_system/components/app_button.dart';
+import 'package:apatie/design_system/components/app_card.dart';
+import 'package:apatie/design_system/components/app_component_states.dart';
+import 'package:apatie/design_system/components/app_label.dart';
+import 'package:apatie/design_system/components/app_progress_indicator.dart';
+import 'package:apatie/design_system/foundations/radii.dart';
+import 'package:apatie/design_system/foundations/spacing.dart';
+
+class ServicesFloatingWindowPattern extends StatefulWidget {
+  const ServicesFloatingWindowPattern({super.key});
+
+  @override
+  State<ServicesFloatingWindowPattern> createState() =>
+      _ServicesFloatingWindowPatternState();
+}
+
+class _ServicesFloatingWindowPatternState
+    extends State<ServicesFloatingWindowPattern> {
+  Offset _offset = const Offset(AppSpacing.lg, AppSpacing.lg);
+  bool _minimized = false;
+
+  void _toggleMinimize() {
+    setState(() => _minimized = !_minimized);
+  }
+
+  void _finishMonitoring(BuildContext context) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('پایش زنده با موفقیت پایان یافت.'),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const double windowWidth = 320;
+        final double windowHeight = _minimized ? 140 : 260;
+        final double maxX = (constraints.maxWidth - windowWidth).clamp(0.0, double.infinity);
+        final double maxY = (constraints.maxHeight - windowHeight).clamp(0.0, double.infinity);
+        final Offset effectiveOffset = Offset(
+          _offset.dx.clamp(0, maxX),
+          _offset.dy.clamp(0, maxY),
+        );
+
+        return Stack(
+          children: [
+            AppCard(
+              header: Text(
+                'پایش زندهٔ سرویس‌های فعال',
+                style: theme.textTheme.titleLarge
+                    ?.copyWith(fontWeight: FontWeight.w600),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'در این نما وضعیت سرویس‌های حیاتی به شکل رسمی و قابل‌اتکا نمایش داده می‌شود. '
+                    'برای مشاهدهٔ جزئیات یک سرویس، پنجرهٔ شناور را جابه‌جا کنید.',
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  AppLabel(
+                    text: 'آخرین به‌روزرسانی: کمتر از ۳۰ ثانیه پیش',
+                    tone: AppComponentStatus.success,
+                  ),
+                  const SizedBox(height: AppSpacing.lg),
+                  AppProgressIndicator(
+                    value: 0.75,
+                    description: 'پایش کلی سامانه با اطمینان ۷۵ درصد تکمیل شده است.',
+                  ),
+                ],
+              ),
+            ),
+            Positioned(
+              left: effectiveOffset.dx,
+              top: effectiveOffset.dy,
+              child: GestureDetector(
+                onPanUpdate: (details) {
+                  setState(() {
+                    final double nextX = (_offset.dx + details.delta.dx).clamp(0, maxX);
+                    final double nextY = (_offset.dy + details.delta.dy).clamp(0, maxY);
+                    _offset = Offset(nextX, nextY);
+                  });
+                },
+                child: Semantics(
+                  container: true,
+                  label: 'پنجرهٔ شناور برای پایش زنده',
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    width: windowWidth,
+                    height: windowHeight,
+                    padding: const EdgeInsets.all(AppSpacing.md),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.surfaceVariant,
+                      borderRadius: AppRadii.lgRadius,
+                      boxShadow: const [
+                        BoxShadow(
+                          blurRadius: 16,
+                          offset: Offset(0, 4),
+                          color: Color(0x33000000),
+                        ),
+                      ],
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              'پایش زندهٔ سرویس پشتیبانی',
+                              style: theme.textTheme.titleSmall
+                                  ?.copyWith(fontWeight: FontWeight.w600),
+                            ),
+                            AppLabel(
+                              text: _minimized ? 'حالت فشرده' : 'فعال',
+                              tone: _minimized
+                                  ? AppComponentStatus.warning
+                                  : AppComponentStatus.success,
+                              compact: true,
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: AppSpacing.sm),
+                        Expanded(
+                          child: _minimized
+                              ? Center(
+                                  child: Text(
+                                    'پنجره در حالت فشرده قرار دارد. برای مشاهدهٔ جزئیات روی «بازگشایی» بزنید.',
+                                    style: theme.textTheme.bodySmall,
+                                    textAlign: TextAlign.center,
+                                  ),
+                                )
+                              : Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      'زمان پاسخ‌گویی متوسط: ۱ دقیقه و ۴۵ ثانیه',
+                                      style: theme.textTheme.bodyMedium,
+                                    ),
+                                    const SizedBox(height: AppSpacing.sm),
+                                    AppProgressIndicator(
+                                      value: 0.45,
+                                      compact: true,
+                                      description:
+                                          'در حال پردازش درخواست‌های فوری کاربران سازمانی.',
+                                      tone: AppComponentStatus.info,
+                                    ),
+                                    const SizedBox(height: AppSpacing.sm),
+                                    Text(
+                                      'آخرین پیام رسمی: «درخواست شماره ۹۸۶ در حال بررسی نهایی است.»',
+                                      style: theme.textTheme.bodySmall,
+                                    ),
+                                  ],
+                                ),
+                        ),
+                        const SizedBox(height: AppSpacing.sm),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            AppButton(
+                              label: _minimized ? 'بازگشایی پنجره' : 'کوچک‌سازی',
+                              compact: true,
+                              onPressed: _toggleMinimize,
+                            ),
+                            const SizedBox(width: AppSpacing.sm),
+                            AppButton(
+                              label: 'پایان پایش',
+                              compact: true,
+                              tone: AppComponentStatus.error,
+                              onPressed: () => _finishMonitoring(context),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class ServicesFloatingWindowPatternPage extends StatelessWidget {
+  const ServicesFloatingWindowPatternPage({super.key});
+
+  static const String routeName = 'servicesFloatingWindow';
+  static const String routePath = 'floating-window';
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: const ServicesFloatingWindowPattern(),
+      ),
+    );
+  }
+}

--- a/frontend/flutter_app/lib/modules/services/ui/screens/services_page.dart
+++ b/frontend/flutter_app/lib/modules/services/ui/screens/services_page.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:apatie/design_system/components/app_button.dart';
+import 'package:apatie/design_system/foundations/spacing.dart';
 import 'package:apatie/l10n/app_localizations.dart';
+import 'package:apatie/modules/services/ui/patterns/floating_window/services_floating_window_pattern.dart';
 
 class ServicesPage extends StatelessWidget {
   const ServicesPage({super.key});
@@ -11,11 +15,41 @@ class ServicesPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context);
 
-    return Center(
-      child: Text(
-        localizations.servicesHeadline,
-        style: Theme.of(context).textTheme.headlineMedium,
-        textAlign: TextAlign.center,
+    return SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              localizations.servicesHeadline,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineSmall
+                  ?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'پایش زنده باید دسترسی آسان، پیام‌های رسمی و حداکثر دو کنش اصلی داشته باشد.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: AppSpacing.xl),
+            ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 360, maxHeight: 520),
+              child: const ServicesFloatingWindowPattern(),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Align(
+              alignment: AlignmentDirectional.centerEnd,
+              child: AppButton(
+                label: 'نمایش پنجرهٔ شناور در مسیر مستقل',
+                onPressed: () => context.push(
+                  '${ServicesPage.routePath}/${ServicesFloatingWindowPatternPage.routePath}',
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- build the multi-step appointment booking pattern and surface it from the appointments page
- add horizontal card bar and dialog card patterns to support marketplace search and comparison flows
- introduce the live monitoring floating window pattern and register dedicated GoRouter demo routes for all patterns

## Testing
- not run (flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ed56a96c4483208933a33132824368