### PR TITLE
Refactor API viewsets into shared module

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,0 +1,41 @@
+"""Public API utilities and viewsets."""
+
+from __future__ import annotations
+
+__all__ = [
+    "DefaultPagination",
+    "IsOwnerOrReadOnly",
+    "AutoModelViewSet",
+    "AppointmentViewSet",
+    "BusinessProfileViewSet",
+    "ListingViewSet",
+    "NotificationViewSet",
+    "PaymentTransactionViewSet",
+    "ServiceViewSet",
+    "UserViewSet",
+]
+
+
+def __getattr__(name: str):
+    if name == "DefaultPagination":
+        from api.pagination import DefaultPagination as attr
+
+        return attr
+    if name == "IsOwnerOrReadOnly":
+        from api.permissions import IsOwnerOrReadOnly as attr
+
+        return attr
+    if name in {
+        "AutoModelViewSet",
+        "AppointmentViewSet",
+        "BusinessProfileViewSet",
+        "ListingViewSet",
+        "NotificationViewSet",
+        "PaymentTransactionViewSet",
+        "ServiceViewSet",
+        "UserViewSet",
+    }:
+        from api import viewsets as viewsets_module
+
+        return getattr(viewsets_module, name)
+    raise AttributeError(name)

--- a/backend/api/filters.py
+++ b/backend/api/filters.py
@@ -1,0 +1,41 @@
+"""Dynamic filterset factories for model-backed endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Sequence
+
+from django.db import models
+from django_filters import rest_framework as filters
+
+__all__ = ["build_filterset_for_model"]
+
+
+def _resolve_filter_fields(model: type[models.Model], fields: Iterable[str] | None) -> Sequence[str]:
+    if fields is not None:
+        return tuple(dict.fromkeys(fields))
+
+    resolved: list[str] = []
+    for field in model._meta.get_fields():
+        if getattr(field, "auto_created", False) and not getattr(field, "concrete", False):
+            continue
+        if getattr(field, "many_to_many", False) and getattr(field, "auto_created", False):
+            continue
+        if not getattr(field, "concrete", False) and not getattr(field, "many_to_many", False):
+            continue
+        resolved.append(field.name)
+    return tuple(dict.fromkeys(resolved))
+
+
+def build_filterset_for_model(
+    model: type[models.Model], *, fields: Iterable[str] | None = None
+) -> type[filters.FilterSet]:
+    """Return a ``FilterSet`` subclass configured for the given model."""
+
+    resolved_fields = _resolve_filter_fields(model, fields)
+
+    meta_attrs: dict[str, object] = {"model": model, "fields": resolved_fields}
+    meta = type("Meta", (), meta_attrs)
+
+    filterset_name = f"{model.__name__}AutoFilterSet"
+    return type(filterset_name, (filters.FilterSet,), {"Meta": meta})

--- a/backend/api/pagination.py
+++ b/backend/api/pagination.py
@@ -1,6 +1,10 @@
 """Pagination utilities for the public API."""
 
+from __future__ import annotations
+
 from rest_framework.pagination import PageNumberPagination
+
+__all__ = ["DefaultPagination"]
 
 
 class DefaultPagination(PageNumberPagination):

--- a/backend/api/permissions.py
+++ b/backend/api/permissions.py
@@ -22,14 +22,19 @@ class IsOwnerOrReadOnly(permissions.BasePermission):
         if getattr(request.user, "is_staff", False):
             return True
 
-        owner_attr = getattr(view, "owner_attribute", self.owner_attribute)
-        owner: Any = getattr(obj, owner_attr, None)
+        owner_lookup_attributes = [
+            getattr(view, "owner_attribute", self.owner_attribute),
+            "user",
+            "recipient",
+            "customer",
+        ]
 
-        if owner is None and hasattr(obj, "user"):
-            owner = getattr(obj, "user")
-
-        if owner is None and hasattr(obj, "recipient"):
-            owner = getattr(obj, "recipient")
+        owner: Any = None
+        for attr in owner_lookup_attributes:
+            candidate = getattr(obj, attr, None)
+            if candidate is not None:
+                owner = candidate
+                break
 
         if owner is None:
             return False

--- a/backend/api/permissions.py
+++ b/backend/api/permissions.py
@@ -1,0 +1,43 @@
+"""Reusable permission classes for the API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.contrib.auth import get_user_model
+from rest_framework import permissions
+
+__all__ = ["IsOwnerOrReadOnly"]
+
+
+class IsOwnerOrReadOnly(permissions.BasePermission):
+    """Allow edits only for object owners while staff retain full access."""
+
+    owner_attribute = "owner"
+
+    def has_object_permission(self, request, view, obj):  # type: ignore[override]
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        if getattr(request.user, "is_staff", False):
+            return True
+
+        owner_attr = getattr(view, "owner_attribute", self.owner_attribute)
+        owner: Any = getattr(obj, owner_attr, None)
+
+        if owner is None and hasattr(obj, "user"):
+            owner = getattr(obj, "user")
+
+        if owner is None and hasattr(obj, "recipient"):
+            owner = getattr(obj, "recipient")
+
+        if owner is None:
+            return False
+
+        if isinstance(owner, get_user_model()):
+            return owner == request.user
+
+        if hasattr(owner, "pk"):
+            return owner.pk == getattr(request.user, "pk", None)
+
+        return owner == request.user

--- a/backend/api/routers.py
+++ b/backend/api/routers.py
@@ -1,0 +1,26 @@
+"""Router configuration for the public API."""
+
+from __future__ import annotations
+
+from rest_framework.routers import DefaultRouter
+
+from api.viewsets import (
+    AppointmentViewSet,
+    BusinessProfileViewSet,
+    ListingViewSet,
+    NotificationViewSet,
+    PaymentTransactionViewSet,
+    ServiceViewSet,
+    UserViewSet,
+)
+
+__all__ = ["router"]
+
+router = DefaultRouter()
+router.register("users", UserViewSet, basename="users")
+router.register("businesses", BusinessProfileViewSet, basename="businesses")
+router.register("services", ServiceViewSet, basename="services")
+router.register("listings", ListingViewSet, basename="listings")
+router.register("appointments", AppointmentViewSet, basename="appointments")
+router.register("payments", PaymentTransactionViewSet, basename="payments")
+router.register("notifications", NotificationViewSet, basename="notifications")

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,0 +1,47 @@
+"""Utilities for dynamically constructing DRF serializers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Sequence
+
+from django.db import models
+from rest_framework import serializers
+
+__all__ = ["build_model_serializer"]
+
+
+def _resolve_serializer_fields(
+    model: type[models.Model], fields: Iterable[str] | None
+) -> Sequence[str]:
+    if fields is not None:
+        return tuple(dict.fromkeys(fields))
+
+    resolved: list[str] = []
+    for field in model._meta.get_fields():
+        if getattr(field, "auto_created", False) and not getattr(field, "concrete", False):
+            continue
+        if getattr(field, "concrete", False) or getattr(field, "many_to_many", False):
+            resolved.append(field.name)
+    return tuple(dict.fromkeys(resolved))
+
+
+def build_model_serializer(
+    model: type[models.Model],
+    *,
+    fields: Iterable[str] | None = None,
+    read_only_fields: Iterable[str] | None = None,
+) -> type[serializers.ModelSerializer]:
+    """Create a ``ModelSerializer`` subclass for ``model``."""
+
+    resolved_fields = _resolve_serializer_fields(model, fields)
+    read_only = tuple(dict.fromkeys(read_only_fields or ()))
+
+    meta_attrs: dict[str, object] = {"model": model, "fields": resolved_fields}
+    if read_only:
+        meta_attrs["read_only_fields"] = read_only
+
+    meta = type("Meta", (), meta_attrs)
+    serializer_name = f"{model.__name__}AutoSerializer"
+
+    return type(serializer_name, (serializers.ModelSerializer,), {"Meta": meta})

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -3,26 +3,10 @@
 from __future__ import annotations
 
 from django.urls import include, path
-from rest_framework import routers
 
-from appointments.viewsets import AppointmentViewSet
-from business.viewsets import BusinessProfileViewSet
-from marketplace.viewsets import ListingViewSet
-from notifications.viewsets import NotificationViewSet
-from payments.viewsets import PaymentTransactionViewSet
-from services.viewsets import ServiceViewSet
-from users.viewsets import UserViewSet
+from api.routers import router
 
 app_name = "api"
-
-router = routers.DefaultRouter()
-router.register(r"users", UserViewSet, basename="user")
-router.register(r"businesses", BusinessProfileViewSet, basename="business")
-router.register(r"services", ServiceViewSet, basename="service")
-router.register(r"listings", ListingViewSet, basename="listing")
-router.register(r"appointments", AppointmentViewSet, basename="appointment")
-router.register(r"payments", PaymentTransactionViewSet, basename="payment")
-router.register(r"notifications", NotificationViewSet, basename="notification")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/backend/api/viewsets.py
+++ b/backend/api/viewsets.py
@@ -263,7 +263,7 @@ class PaymentTransactionViewSet(AutoModelViewSet):
         payment = self.get_object()
         gateway = self.gateway_class()
         result = gateway.charge(
-            amount=float(payment.amount),
+            amount=payment.amount,
             currency=payment.currency,
             metadata={"reference": str(payment.pk)},
         )

--- a/backend/api/viewsets.py
+++ b/backend/api/viewsets.py
@@ -1,0 +1,311 @@
+"""Generic, auto-configured viewsets for public API resources."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import ClassVar, TypeVar
+
+from django.core.exceptions import ImproperlyConfigured
+from django.db import models
+from django_filters import rest_framework as django_filters
+from rest_framework import filters as drf_filters
+from rest_framework import permissions, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from api.filters import build_filterset_for_model
+from api.pagination import DefaultPagination
+from api.serializers import build_model_serializer
+from appointments.models import Appointment
+from business.models import BusinessProfile
+from marketplace.models import Listing
+from notifications.adapters import MockNotificationService
+from notifications.models import Notification
+from payments.adapters import MockPaymentGateway
+from payments.models import PaymentTransaction
+from services.models import Service
+from users.models import User
+
+ModelT = TypeVar("ModelT", bound=models.Model)
+
+__all__ = [
+    "AutoModelViewSet",
+    "UserViewSet",
+    "BusinessProfileViewSet",
+    "ServiceViewSet",
+    "ListingViewSet",
+    "AppointmentViewSet",
+    "PaymentTransactionViewSet",
+    "NotificationViewSet",
+]
+
+
+class AutoModelViewSet(viewsets.ModelViewSet):
+    """Base class that auto-wires serializer, filterset and pagination."""
+
+    model: ClassVar[type[ModelT] | None] = None
+    serializer_fields: ClassVar[Sequence[str] | None] = None
+    serializer_read_only_fields: ClassVar[Sequence[str] | None] = None
+    filterset_fields: ClassVar[Sequence[str] | None | bool] = None
+    select_related: ClassVar[Sequence[str]] = ()
+    prefetch_related: ClassVar[Sequence[str]] = ()
+
+    pagination_class = DefaultPagination
+    permission_classes = [permissions.IsAuthenticated]
+    filter_backends = (
+        django_filters.DjangoFilterBackend,
+        drf_filters.SearchFilter,
+        drf_filters.OrderingFilter,
+    )
+    ordering_fields = "__all__"
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        model = getattr(cls, "model", None)
+        if model is None:
+            return
+
+        serializer_fields = getattr(cls, "serializer_fields", None)
+        default_read_only = cls._default_read_only_fields_for_model(model)
+        extra_read_only = getattr(cls, "serializer_read_only_fields", None)
+        if extra_read_only:
+            read_only = tuple(sorted({*default_read_only, *extra_read_only}))
+        else:
+            read_only = default_read_only
+
+        if getattr(cls, "serializer_class", None) is None:
+            cls.serializer_class = build_model_serializer(
+                model, fields=serializer_fields, read_only_fields=read_only
+            )
+
+        filterset_fields = getattr(cls, "filterset_fields", None)
+        if getattr(cls, "filterset_class", None) is None and filterset_fields is not False:
+            candidate_fields: Sequence[str] | None
+            if isinstance(filterset_fields, Sequence):
+                candidate_fields = filterset_fields
+            elif serializer_fields is not None:
+                candidate_fields = serializer_fields
+            else:
+                candidate_fields = None
+            cls.filterset_class = build_filterset_for_model(
+                model, fields=candidate_fields
+            )
+
+    @staticmethod
+    def _default_read_only_fields_for_model(model: type[models.Model]) -> Sequence[str]:
+        fields: set[str] = set()
+        pk = model._meta.pk
+        if pk is not None:
+            fields.add(pk.name)
+        for field in model._meta.get_fields():
+            if getattr(field, "auto_now", False) or getattr(field, "auto_now_add", False):
+                fields.add(field.name)
+        return tuple(sorted(fields))
+
+    def get_queryset(self):  # type: ignore[override]
+        model = getattr(self, "model", None)
+        if model is None:
+            raise ImproperlyConfigured("AutoModelViewSet subclasses must define a model")
+
+        queryset = model._default_manager.all()
+        if self.select_related:
+            queryset = queryset.select_related(*self.select_related)
+        if self.prefetch_related:
+            queryset = queryset.prefetch_related(*self.prefetch_related)
+
+        ordering = getattr(self, "ordering", None)
+        if ordering:
+            queryset = queryset.order_by(*ordering)
+        elif model._meta.ordering:
+            queryset = queryset.order_by(*model._meta.ordering)
+
+        return queryset
+
+
+class UserViewSet(AutoModelViewSet):
+    """Viewset for user accounts."""
+
+    model = User
+    serializer_fields = (
+        "id",
+        "email",
+        "full_name",
+        "is_active",
+        "created_at",
+        "updated_at",
+    )
+    serializer_read_only_fields = ("is_active",)
+    search_fields = ("email", "full_name")
+
+
+class BusinessProfileViewSet(AutoModelViewSet):
+    """Viewset for business profiles."""
+
+    model = BusinessProfile
+    serializer_fields = (
+        "id",
+        "owner",
+        "name",
+        "description",
+        "created_at",
+        "updated_at",
+    )
+    serializer_read_only_fields = ("owner",)
+    select_related = ("owner",)
+    search_fields = ("name", "description", "owner__email")
+
+    def perform_create(self, serializer):  # type: ignore[override]
+        serializer.save(owner=self.request.user)
+
+
+class ServiceViewSet(AutoModelViewSet):
+    """Viewset for services offered by businesses."""
+
+    model = Service
+    serializer_fields = (
+        "id",
+        "business",
+        "name",
+        "description",
+        "duration_minutes",
+        "created_at",
+        "updated_at",
+    )
+    select_related = ("business",)
+    search_fields = ("name", "description", "business__name")
+
+    def get_queryset(self):  # type: ignore[override]
+        queryset = super().get_queryset()
+        user = self.request.user
+        if getattr(user, "is_staff", False):
+            return queryset
+        return queryset.filter(business__owner=user)
+
+
+class ListingViewSet(AutoModelViewSet):
+    """Viewset for marketplace listings."""
+
+    model = Listing
+    serializer_fields = (
+        "id",
+        "business",
+        "service",
+        "price",
+        "is_active",
+        "created_at",
+        "updated_at",
+    )
+    select_related = ("business", "service")
+    search_fields = (
+        "service__name",
+        "business__name",
+    )
+
+    def get_queryset(self):  # type: ignore[override]
+        queryset = super().get_queryset()
+        user = self.request.user
+        if getattr(user, "is_staff", False):
+            return queryset
+        return queryset.filter(business__owner=user)
+
+
+class AppointmentViewSet(AutoModelViewSet):
+    """Viewset for appointments."""
+
+    model = Appointment
+    serializer_fields = (
+        "id",
+        "customer",
+        "business",
+        "service",
+        "scheduled_for",
+        "status",
+        "notes",
+        "created_at",
+        "updated_at",
+    )
+    select_related = ("customer", "business", "service")
+    search_fields = ("customer__email", "status", "business__name", "service__name")
+
+    def get_queryset(self):  # type: ignore[override]
+        queryset = super().get_queryset()
+        user = self.request.user
+        if getattr(user, "is_staff", False):
+            return queryset
+        return queryset.filter(customer=user)
+
+
+class PaymentTransactionViewSet(AutoModelViewSet):
+    """Viewset for payment transactions."""
+
+    model = PaymentTransaction
+    serializer_fields = (
+        "id",
+        "appointment",
+        "amount",
+        "currency",
+        "status",
+        "external_reference",
+        "created_at",
+        "updated_at",
+    )
+    serializer_read_only_fields = ("status", "external_reference")
+    select_related = ("appointment",)
+    search_fields = ("status", "currency", "appointment__customer__email")
+    gateway_class = MockPaymentGateway
+
+    def perform_create(self, serializer):  # type: ignore[override]
+        serializer.save(status="pending")
+
+    @action(detail=True, methods=["post"], url_path="capture")
+    def capture(self, request: Request, *args, **kwargs):
+        payment = self.get_object()
+        gateway = self.gateway_class()
+        result = gateway.charge(
+            amount=float(payment.amount),
+            currency=payment.currency,
+            metadata={"reference": str(payment.pk)},
+        )
+        payment.mark_completed(result.reference)
+        serializer = self.get_serializer(payment)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class NotificationViewSet(AutoModelViewSet):
+    """Viewset for user notifications."""
+
+    model = Notification
+    serializer_fields = (
+        "id",
+        "recipient",
+        "subject",
+        "body",
+        "read_at",
+        "created_at",
+        "updated_at",
+    )
+    serializer_read_only_fields = ("read_at",)
+    select_related = ("recipient",)
+    search_fields = ("subject", "body", "recipient__email")
+    notification_service_class = MockNotificationService
+
+    def get_queryset(self):  # type: ignore[override]
+        queryset = super().get_queryset()
+        user = self.request.user
+        if getattr(user, "is_staff", False):
+            return queryset
+        return queryset.filter(recipient=user)
+
+    @action(detail=False, methods=["post"], url_path="send-test")
+    def send_test_notification(self, request: Request, *args, **kwargs):
+        notification_service = self.notification_service_class()
+        result = notification_service.send(
+            recipient=request.user.email,
+            subject="Test notification",
+            body="This is a mock notification.",
+        )
+        return Response(
+            {"success": result.success, "message": result.message},
+            status=status.HTTP_200_OK,
+        )

--- a/backend/appointments/viewsets.py
+++ b/backend/appointments/viewsets.py
@@ -1,23 +1,7 @@
-"""Viewsets for appointment resources."""
+"""Appointments viewsets reference the consolidated API implementation."""
 
 from __future__ import annotations
 
-from rest_framework import permissions, viewsets
+from api.viewsets import AppointmentViewSet
 
-from .models import Appointment
-from .serializers import AppointmentSerializer
-
-
-class AppointmentViewSet(viewsets.ModelViewSet):
-    queryset = Appointment.objects.select_related(
-        "customer", "business", "service"
-    ).all()
-    serializer_class = AppointmentSerializer
-    permission_classes = [permissions.IsAuthenticated]
-
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        user = self.request.user
-        if user.is_staff:
-            return queryset
-        return queryset.filter(customer=user)
+__all__ = ["AppointmentViewSet"]

--- a/backend/business/viewsets.py
+++ b/backend/business/viewsets.py
@@ -1,17 +1,7 @@
-"""Viewsets for business resources."""
+"""Business viewsets are sourced from the central API module."""
 
 from __future__ import annotations
 
-from rest_framework import permissions, viewsets
+from api.viewsets import BusinessProfileViewSet
 
-from .models import BusinessProfile
-from .serializers import BusinessProfileSerializer
-
-
-class BusinessProfileViewSet(viewsets.ModelViewSet):
-    queryset = BusinessProfile.objects.select_related("owner").all()
-    serializer_class = BusinessProfileSerializer
-    permission_classes = [permissions.IsAuthenticated]
-
-    def perform_create(self, serializer):
-        serializer.save(owner=self.request.user)
+__all__ = ["BusinessProfileViewSet"]

--- a/backend/marketplace/viewsets.py
+++ b/backend/marketplace/viewsets.py
@@ -1,20 +1,7 @@
-"""Viewsets for marketplace listings."""
+"""Marketplace viewsets provided by the shared API module."""
 
 from __future__ import annotations
 
-from rest_framework import permissions, viewsets
+from api.viewsets import ListingViewSet
 
-from .models import Listing
-from .serializers import ListingSerializer
-
-
-class ListingViewSet(viewsets.ModelViewSet):
-    queryset = Listing.objects.select_related("business", "service").all()
-    serializer_class = ListingSerializer
-    permission_classes = [permissions.IsAuthenticated]
-
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        if self.request.user.is_staff:
-            return queryset
-        return queryset.filter(business__owner=self.request.user)
+__all__ = ["ListingViewSet"]

--- a/backend/notifications/viewsets.py
+++ b/backend/notifications/viewsets.py
@@ -1,37 +1,7 @@
-"""Viewsets for notifications."""
+"""Notification viewsets delegate to the shared API implementation."""
 
 from __future__ import annotations
 
-from rest_framework import permissions, status, viewsets
-from rest_framework.decorators import action
-from rest_framework.response import Response
+from api.viewsets import NotificationViewSet
 
-from .adapters import MockNotificationService
-from .models import Notification
-from .serializers import NotificationSerializer
-
-
-class NotificationViewSet(viewsets.ModelViewSet):
-    queryset = Notification.objects.select_related("recipient").all()
-    serializer_class = NotificationSerializer
-    permission_classes = [permissions.IsAuthenticated]
-    notification_service_class = MockNotificationService
-
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        if self.request.user.is_staff:
-            return queryset
-        return queryset.filter(recipient=self.request.user)
-
-    @action(detail=False, methods=["post"], url_path="send-test")
-    def send_test_notification(self, request, *args, **kwargs):
-        notification_service = self.notification_service_class()
-        result = notification_service.send(
-            recipient=request.user.email,
-            subject="Test notification",
-            body="This is a mock notification.",
-        )
-        return Response(
-            {"success": result.success, "message": result.message},
-            status=status.HTTP_200_OK,
-        )
+__all__ = ["NotificationViewSet"]

--- a/backend/payments/viewsets.py
+++ b/backend/payments/viewsets.py
@@ -1,34 +1,7 @@
-"""Viewsets for payment resources."""
+"""Payment viewsets import the centralized API implementation."""
 
 from __future__ import annotations
 
-from rest_framework import permissions, status, viewsets
-from rest_framework.decorators import action
-from rest_framework.response import Response
+from api.viewsets import PaymentTransactionViewSet
 
-from .adapters import MockPaymentGateway
-from .models import PaymentTransaction
-from .serializers import PaymentTransactionSerializer
-
-
-class PaymentTransactionViewSet(viewsets.ModelViewSet):
-    queryset = PaymentTransaction.objects.select_related("appointment").all()
-    serializer_class = PaymentTransactionSerializer
-    permission_classes = [permissions.IsAuthenticated]
-    gateway_class = MockPaymentGateway
-
-    def perform_create(self, serializer):
-        serializer.save(status="pending")
-
-    @action(detail=True, methods=["post"], url_path="capture")
-    def capture(self, request, *args, **kwargs):
-        payment = self.get_object()
-        gateway = self.gateway_class()
-        result = gateway.charge(
-            amount=float(payment.amount),
-            currency=payment.currency,
-            metadata={"reference": str(payment.pk)},
-        )
-        payment.mark_completed(result.reference)
-        serializer = self.get_serializer(payment)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+__all__ = ["PaymentTransactionViewSet"]

--- a/backend/services/viewsets.py
+++ b/backend/services/viewsets.py
@@ -1,20 +1,7 @@
-"""Viewsets for services."""
+"""Service viewsets delegate to the API module."""
 
 from __future__ import annotations
 
-from rest_framework import permissions, viewsets
+from api.viewsets import ServiceViewSet
 
-from .models import Service
-from .serializers import ServiceSerializer
-
-
-class ServiceViewSet(viewsets.ModelViewSet):
-    queryset = Service.objects.select_related("business").all()
-    serializer_class = ServiceSerializer
-    permission_classes = [permissions.IsAuthenticated]
-
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        if self.request.user.is_staff:
-            return queryset
-        return queryset.filter(business__owner=self.request.user)
+__all__ = ["ServiceViewSet"]

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -19,7 +19,7 @@ def test_jwt_auth_flow(api_client, user_factory):
     assert "access" in tokens and "refresh" in tokens
 
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {tokens['access']}")
-    user_list_url = reverse("api:user-list")
+    user_list_url = reverse("api:users-list")
     list_response = api_client.get(user_list_url)
 
     assert list_response.status_code == 200

--- a/backend/tests/test_viewsets_and_models.py
+++ b/backend/tests/test_viewsets_and_models.py
@@ -34,7 +34,7 @@ def test_appointment_queryset_scoped_for_regular_users(
     appointment_factory(customer=other_customer)
 
     api_client.force_authenticate(customer)
-    response = api_client.get(reverse("api:appointment-list"))
+    response = api_client.get(reverse("api:appointments-list"))
 
     assert response.status_code == 200
     appointment_ids = {item["id"] for item in extract_results(response.json())}
@@ -43,7 +43,7 @@ def test_appointment_queryset_scoped_for_regular_users(
 
 @pytest.mark.django_db
 def test_anonymous_user_cannot_list_business_profiles(api_client):
-    response = api_client.get(reverse("api:business-list"))
+    response = api_client.get(reverse("api:businesses-list"))
 
     assert response.status_code in {
         status.HTTP_401_UNAUTHORIZED,
@@ -59,7 +59,7 @@ def test_anonymous_user_cannot_retrieve_business_profile(
 ):
     profile = business_profile_factory()
 
-    response = api_client.get(reverse("api:business-detail", args=[profile.pk]))
+    response = api_client.get(reverse("api:businesses-detail", args=[profile.pk]))
 
     assert response.status_code in {
         status.HTTP_401_UNAUTHORIZED,
@@ -76,7 +76,7 @@ def test_appointment_queryset_visible_to_staff(api_client, appointment_factory, 
     second_appointment = appointment_factory()
 
     api_client.force_authenticate(staff_user)
-    response = api_client.get(reverse("api:appointment-list"))
+    response = api_client.get(reverse("api:appointments-list"))
 
     assert response.status_code == 200
     appointment_ids = {item["id"] for item in extract_results(response.json())}
@@ -95,7 +95,7 @@ def test_service_queryset_filtered_for_business_owner(
     service_factory(business=business_profile_factory(owner=other_owner))
 
     api_client.force_authenticate(owner)
-    response = api_client.get(reverse("api:service-list"))
+    response = api_client.get(reverse("api:services-list"))
 
     assert response.status_code == 200
     service_ids = {item["id"] for item in extract_results(response.json())}
@@ -109,7 +109,7 @@ def test_service_queryset_visible_to_staff(api_client, service_factory, user_fac
     service_two = service_factory()
 
     api_client.force_authenticate(staff_user)
-    response = api_client.get(reverse("api:service-list"))
+    response = api_client.get(reverse("api:services-list"))
 
     assert response.status_code == 200
     service_ids = {item["id"] for item in extract_results(response.json())}
@@ -132,7 +132,7 @@ def test_listing_queryset_filtered_for_business_owner(
     listing_factory(service=other_service, business=other_business)
 
     api_client.force_authenticate(owner)
-    response = api_client.get(reverse("api:listing-list"))
+    response = api_client.get(reverse("api:listings-list"))
 
     assert response.status_code == 200
     listing_ids = {item["id"] for item in extract_results(response.json())}
@@ -146,7 +146,7 @@ def test_listing_queryset_visible_to_staff(api_client, listing_factory, user_fac
     listing_two = listing_factory()
 
     api_client.force_authenticate(staff_user)
-    response = api_client.get(reverse("api:listing-list"))
+    response = api_client.get(reverse("api:listings-list"))
 
     assert response.status_code == 200
     listing_ids = {item["id"] for item in extract_results(response.json())}
@@ -160,7 +160,7 @@ def test_business_profile_owner_is_request_user(api_client, user_factory):
 
     api_client.force_authenticate(authenticated_user)
     response = api_client.post(
-        reverse("api:business-list"),
+        reverse("api:businesses-list"),
         data={
             "name": "Creator Business",
             "description": "Created via API",
@@ -199,7 +199,7 @@ def test_notification_send_test_action_invokes_adapter(
 
     user = user_factory(email="notify@example.com")
     api_client.force_authenticate(user)
-    response = api_client.post(reverse("api:notification-send-test-notification"))
+    response = api_client.post(reverse("api:notifications-send-test-notification"))
 
     assert response.status_code == 200
     assert response.json() == {"success": True, "message": "queued"}
@@ -237,7 +237,7 @@ def test_payment_capture_updates_transaction(
     user = user_factory(email="payments@example.com")
 
     api_client.force_authenticate(user)
-    response = api_client.post(reverse("api:payment-capture", args=[payment.pk]))
+    response = api_client.post(reverse("api:payments-capture", args=[payment.pk]))
 
     assert response.status_code == 200
     data = response.json()

--- a/backend/users/viewsets.py
+++ b/backend/users/viewsets.py
@@ -1,14 +1,7 @@
-"""Viewsets for user resources."""
+"""User viewsets reuse the shared API definitions."""
 
 from __future__ import annotations
 
-from rest_framework import permissions, viewsets
+from api.viewsets import UserViewSet
 
-from .models import User
-from .serializers import UserSerializer
-
-
-class UserViewSet(viewsets.ModelViewSet):
-    queryset = User.objects.all().order_by("-created_at")
-    serializer_class = UserSerializer
-    permission_classes = [permissions.IsAuthenticated]
+__all__ = ["UserViewSet"]


### PR DESCRIPTION
## Summary
- add shared API infrastructure modules for pagination, permissions, serializers, filters, and AutoModelViewSet-driven resources
- consolidate domain viewsets into backend/api/viewsets.py and register pluralized routes in a central router
- update legacy app viewset modules and tests to consume the new API endpoints

## Testing
- python backend/manage.py makemigrations --check
- python backend/manage.py shell -c 'from django.urls import get_resolver; resolver = get_resolver(); api_resolver = resolver.namespace_dict["api"][1]; print("\\n".join(sorted(n for n in api_resolver.reverse_dict if isinstance(n,str))))'


------
https://chatgpt.com/codex/tasks/task_e_68ed883334fc8320b38f5f02f593fbcd