### PR TITLE
chore: add golden testing dependencies

### DIFF
--- a/frontend/flutter_app/pubspec.yaml
+++ b/frontend/flutter_app/pubspec.yaml
@@ -26,8 +26,16 @@ dev_dependencies:
   bloc_test: ^10.0.0
   mocktail: ^1.0.3
   flutter_lints: ^6.0.0
+  golden_toolkit: ^0.15.0
+  integration_test:
+    sdk: flutter
 
 flutter:
   uses-material-design: true
+
+  fonts:
+    - family: Roboto
+      fonts:
+        - asset: packages/golden_toolkit/fonts/Roboto-Regular.ttf
 
   generate: true


### PR DESCRIPTION
## Summary
- add the golden_toolkit and integration_test dev dependencies to support upcoming visual and integration testing
- register the Roboto font asset from golden_toolkit so golden tests can render text consistently

## Testing
- flutter pub get *(fails: `flutter` command not available in container)*
- flutter test *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed8d4c0974832091c28dfaf21dbc40