### PR TITLE
Add API test scaffolding and update schema snapshot

### DIFF
--- a/backend/api/schema/openapi.json
+++ b/backend/api/schema/openapi.json
@@ -98,6 +98,7 @@
         "/api/v1/appointments/": {
             "get": {
                 "operationId": "appointments_list",
+                "description": "Viewset for appointments.",
                 "parameters": [
                     {
                         "name": "ordering",
@@ -152,7 +153,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaginatedAppointmentList"
+                                    "$ref": "#/components/schemas/PaginatedAppointmentAutoList"
                                 }
                             }
                         },
@@ -162,6 +163,7 @@
             },
             "post": {
                 "operationId": "appointments_create",
+                "description": "Viewset for appointments.",
                 "tags": [
                     "appointments"
                 ],
@@ -169,17 +171,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/AppointmentRequest"
+                                "$ref": "#/components/schemas/AppointmentAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/AppointmentRequest"
+                                "$ref": "#/components/schemas/AppointmentAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/AppointmentRequest"
+                                "$ref": "#/components/schemas/AppointmentAutoRequest"
                             }
                         }
                     },
@@ -198,7 +200,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Appointment"
+                                    "$ref": "#/components/schemas/AppointmentAuto"
                                 }
                             }
                         },
@@ -210,14 +212,14 @@
         "/api/v1/appointments/{id}/": {
             "get": {
                 "operationId": "appointments_retrieve",
+                "description": "Viewset for appointments.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this appointment.",
                         "required": true
                     }
                 ],
@@ -237,7 +239,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Appointment"
+                                    "$ref": "#/components/schemas/AppointmentAuto"
                                 }
                             }
                         },
@@ -247,14 +249,14 @@
             },
             "put": {
                 "operationId": "appointments_update",
+                "description": "Viewset for appointments.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this appointment.",
                         "required": true
                     }
                 ],
@@ -265,17 +267,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/AppointmentRequest"
+                                "$ref": "#/components/schemas/AppointmentAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/AppointmentRequest"
+                                "$ref": "#/components/schemas/AppointmentAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/AppointmentRequest"
+                                "$ref": "#/components/schemas/AppointmentAutoRequest"
                             }
                         }
                     },
@@ -294,7 +296,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Appointment"
+                                    "$ref": "#/components/schemas/AppointmentAuto"
                                 }
                             }
                         },
@@ -304,14 +306,14 @@
             },
             "patch": {
                 "operationId": "appointments_partial_update",
+                "description": "Viewset for appointments.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this appointment.",
                         "required": true
                     }
                 ],
@@ -322,17 +324,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedAppointmentRequest"
+                                "$ref": "#/components/schemas/PatchedAppointmentAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedAppointmentRequest"
+                                "$ref": "#/components/schemas/PatchedAppointmentAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedAppointmentRequest"
+                                "$ref": "#/components/schemas/PatchedAppointmentAutoRequest"
                             }
                         }
                     }
@@ -350,7 +352,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Appointment"
+                                    "$ref": "#/components/schemas/AppointmentAuto"
                                 }
                             }
                         },
@@ -360,14 +362,14 @@
             },
             "delete": {
                 "operationId": "appointments_destroy",
+                "description": "Viewset for appointments.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this appointment.",
                         "required": true
                     }
                 ],
@@ -392,7 +394,37 @@
         "/api/v1/businesses/": {
             "get": {
                 "operationId": "businesses_list",
+                "description": "Viewset for business profiles.",
                 "parameters": [
+                    {
+                        "in": "query",
+                        "name": "created_at",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "description",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     {
                         "name": "ordering",
                         "required": false,
@@ -400,6 +432,13 @@
                         "description": "Which field to use when ordering the results.",
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "owner",
+                        "schema": {
+                            "type": "integer"
                         }
                     },
                     {
@@ -428,6 +467,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "updated_at",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
                     }
                 ],
                 "tags": [
@@ -446,7 +493,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaginatedBusinessProfileList"
+                                    "$ref": "#/components/schemas/PaginatedBusinessProfileAutoList"
                                 }
                             }
                         },
@@ -456,6 +503,7 @@
             },
             "post": {
                 "operationId": "businesses_create",
+                "description": "Viewset for business profiles.",
                 "tags": [
                     "businesses"
                 ],
@@ -463,17 +511,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/BusinessProfileRequest"
+                                "$ref": "#/components/schemas/BusinessProfileAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/BusinessProfileRequest"
+                                "$ref": "#/components/schemas/BusinessProfileAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/BusinessProfileRequest"
+                                "$ref": "#/components/schemas/BusinessProfileAutoRequest"
                             }
                         }
                     },
@@ -492,7 +540,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/BusinessProfile"
+                                    "$ref": "#/components/schemas/BusinessProfileAuto"
                                 }
                             }
                         },
@@ -504,6 +552,7 @@
         "/api/v1/businesses/{id}/": {
             "get": {
                 "operationId": "businesses_retrieve",
+                "description": "Viewset for business profiles.",
                 "parameters": [
                     {
                         "in": "path",
@@ -531,7 +580,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/BusinessProfile"
+                                    "$ref": "#/components/schemas/BusinessProfileAuto"
                                 }
                             }
                         },
@@ -541,6 +590,7 @@
             },
             "put": {
                 "operationId": "businesses_update",
+                "description": "Viewset for business profiles.",
                 "parameters": [
                     {
                         "in": "path",
@@ -559,17 +609,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/BusinessProfileRequest"
+                                "$ref": "#/components/schemas/BusinessProfileAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/BusinessProfileRequest"
+                                "$ref": "#/components/schemas/BusinessProfileAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/BusinessProfileRequest"
+                                "$ref": "#/components/schemas/BusinessProfileAutoRequest"
                             }
                         }
                     },
@@ -588,7 +638,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/BusinessProfile"
+                                    "$ref": "#/components/schemas/BusinessProfileAuto"
                                 }
                             }
                         },
@@ -598,6 +648,7 @@
             },
             "patch": {
                 "operationId": "businesses_partial_update",
+                "description": "Viewset for business profiles.",
                 "parameters": [
                     {
                         "in": "path",
@@ -616,17 +667,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedBusinessProfileRequest"
+                                "$ref": "#/components/schemas/PatchedBusinessProfileAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedBusinessProfileRequest"
+                                "$ref": "#/components/schemas/PatchedBusinessProfileAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedBusinessProfileRequest"
+                                "$ref": "#/components/schemas/PatchedBusinessProfileAutoRequest"
                             }
                         }
                     }
@@ -644,7 +695,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/BusinessProfile"
+                                    "$ref": "#/components/schemas/BusinessProfileAuto"
                                 }
                             }
                         },
@@ -654,6 +705,7 @@
             },
             "delete": {
                 "operationId": "businesses_destroy",
+                "description": "Viewset for business profiles.",
                 "parameters": [
                     {
                         "in": "path",
@@ -686,6 +738,7 @@
         "/api/v1/listings/": {
             "get": {
                 "operationId": "listings_list",
+                "description": "Viewset for marketplace listings.",
                 "parameters": [
                     {
                         "name": "ordering",
@@ -740,7 +793,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaginatedListingList"
+                                    "$ref": "#/components/schemas/PaginatedListingAutoList"
                                 }
                             }
                         },
@@ -750,6 +803,7 @@
             },
             "post": {
                 "operationId": "listings_create",
+                "description": "Viewset for marketplace listings.",
                 "tags": [
                     "listings"
                 ],
@@ -757,17 +811,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/ListingRequest"
+                                "$ref": "#/components/schemas/ListingAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/ListingRequest"
+                                "$ref": "#/components/schemas/ListingAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/ListingRequest"
+                                "$ref": "#/components/schemas/ListingAutoRequest"
                             }
                         }
                     },
@@ -786,7 +840,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Listing"
+                                    "$ref": "#/components/schemas/ListingAuto"
                                 }
                             }
                         },
@@ -798,14 +852,14 @@
         "/api/v1/listings/{id}/": {
             "get": {
                 "operationId": "listings_retrieve",
+                "description": "Viewset for marketplace listings.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this listing.",
                         "required": true
                     }
                 ],
@@ -825,7 +879,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Listing"
+                                    "$ref": "#/components/schemas/ListingAuto"
                                 }
                             }
                         },
@@ -835,14 +889,14 @@
             },
             "put": {
                 "operationId": "listings_update",
+                "description": "Viewset for marketplace listings.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this listing.",
                         "required": true
                     }
                 ],
@@ -853,17 +907,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/ListingRequest"
+                                "$ref": "#/components/schemas/ListingAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/ListingRequest"
+                                "$ref": "#/components/schemas/ListingAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/ListingRequest"
+                                "$ref": "#/components/schemas/ListingAutoRequest"
                             }
                         }
                     },
@@ -882,7 +936,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Listing"
+                                    "$ref": "#/components/schemas/ListingAuto"
                                 }
                             }
                         },
@@ -892,14 +946,14 @@
             },
             "patch": {
                 "operationId": "listings_partial_update",
+                "description": "Viewset for marketplace listings.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this listing.",
                         "required": true
                     }
                 ],
@@ -910,17 +964,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedListingRequest"
+                                "$ref": "#/components/schemas/PatchedListingAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedListingRequest"
+                                "$ref": "#/components/schemas/PatchedListingAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedListingRequest"
+                                "$ref": "#/components/schemas/PatchedListingAutoRequest"
                             }
                         }
                     }
@@ -938,7 +992,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Listing"
+                                    "$ref": "#/components/schemas/ListingAuto"
                                 }
                             }
                         },
@@ -948,14 +1002,14 @@
             },
             "delete": {
                 "operationId": "listings_destroy",
+                "description": "Viewset for marketplace listings.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this listing.",
                         "required": true
                     }
                 ],
@@ -980,6 +1034,7 @@
         "/api/v1/notifications/": {
             "get": {
                 "operationId": "notifications_list",
+                "description": "Viewset for user notifications.",
                 "parameters": [
                     {
                         "name": "ordering",
@@ -1034,7 +1089,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaginatedNotificationList"
+                                    "$ref": "#/components/schemas/PaginatedNotificationAutoList"
                                 }
                             }
                         },
@@ -1044,6 +1099,7 @@
             },
             "post": {
                 "operationId": "notifications_create",
+                "description": "Viewset for user notifications.",
                 "tags": [
                     "notifications"
                 ],
@@ -1051,17 +1107,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/NotificationRequest"
+                                "$ref": "#/components/schemas/NotificationAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/NotificationRequest"
+                                "$ref": "#/components/schemas/NotificationAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/NotificationRequest"
+                                "$ref": "#/components/schemas/NotificationAutoRequest"
                             }
                         }
                     },
@@ -1080,7 +1136,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Notification"
+                                    "$ref": "#/components/schemas/NotificationAuto"
                                 }
                             }
                         },
@@ -1092,14 +1148,14 @@
         "/api/v1/notifications/{id}/": {
             "get": {
                 "operationId": "notifications_retrieve",
+                "description": "Viewset for user notifications.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this notification.",
                         "required": true
                     }
                 ],
@@ -1119,7 +1175,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Notification"
+                                    "$ref": "#/components/schemas/NotificationAuto"
                                 }
                             }
                         },
@@ -1129,14 +1185,14 @@
             },
             "put": {
                 "operationId": "notifications_update",
+                "description": "Viewset for user notifications.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this notification.",
                         "required": true
                     }
                 ],
@@ -1147,17 +1203,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/NotificationRequest"
+                                "$ref": "#/components/schemas/NotificationAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/NotificationRequest"
+                                "$ref": "#/components/schemas/NotificationAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/NotificationRequest"
+                                "$ref": "#/components/schemas/NotificationAutoRequest"
                             }
                         }
                     },
@@ -1176,7 +1232,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Notification"
+                                    "$ref": "#/components/schemas/NotificationAuto"
                                 }
                             }
                         },
@@ -1186,14 +1242,14 @@
             },
             "patch": {
                 "operationId": "notifications_partial_update",
+                "description": "Viewset for user notifications.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this notification.",
                         "required": true
                     }
                 ],
@@ -1204,17 +1260,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedNotificationRequest"
+                                "$ref": "#/components/schemas/PatchedNotificationAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedNotificationRequest"
+                                "$ref": "#/components/schemas/PatchedNotificationAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedNotificationRequest"
+                                "$ref": "#/components/schemas/PatchedNotificationAutoRequest"
                             }
                         }
                     }
@@ -1232,7 +1288,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Notification"
+                                    "$ref": "#/components/schemas/NotificationAuto"
                                 }
                             }
                         },
@@ -1242,14 +1298,14 @@
             },
             "delete": {
                 "operationId": "notifications_destroy",
+                "description": "Viewset for user notifications.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this notification.",
                         "required": true
                     }
                 ],
@@ -1274,6 +1330,7 @@
         "/api/v1/notifications/send-test/": {
             "post": {
                 "operationId": "notifications_send_test_create",
+                "description": "Viewset for user notifications.",
                 "tags": [
                     "notifications"
                 ],
@@ -1281,17 +1338,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/NotificationRequest"
+                                "$ref": "#/components/schemas/NotificationAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/NotificationRequest"
+                                "$ref": "#/components/schemas/NotificationAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/NotificationRequest"
+                                "$ref": "#/components/schemas/NotificationAutoRequest"
                             }
                         }
                     },
@@ -1310,7 +1367,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Notification"
+                                    "$ref": "#/components/schemas/NotificationAuto"
                                 }
                             }
                         },
@@ -1322,7 +1379,51 @@
         "/api/v1/payments/": {
             "get": {
                 "operationId": "payments_list",
+                "description": "Viewset for payment transactions.",
                 "parameters": [
+                    {
+                        "in": "query",
+                        "name": "amount",
+                        "schema": {
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "appointment",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "created_at",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "currency",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "external_reference",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
                     {
                         "name": "ordering",
                         "required": false,
@@ -1358,6 +1459,21 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "status",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "updated_at",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
                     }
                 ],
                 "tags": [
@@ -1376,7 +1492,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaginatedPaymentTransactionList"
+                                    "$ref": "#/components/schemas/PaginatedPaymentTransactionAutoList"
                                 }
                             }
                         },
@@ -1386,6 +1502,7 @@
             },
             "post": {
                 "operationId": "payments_create",
+                "description": "Viewset for payment transactions.",
                 "tags": [
                     "payments"
                 ],
@@ -1393,17 +1510,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PaymentTransactionRequest"
+                                "$ref": "#/components/schemas/PaymentTransactionAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/PaymentTransactionRequest"
+                                "$ref": "#/components/schemas/PaymentTransactionAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/PaymentTransactionRequest"
+                                "$ref": "#/components/schemas/PaymentTransactionAutoRequest"
                             }
                         }
                     },
@@ -1422,7 +1539,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaymentTransaction"
+                                    "$ref": "#/components/schemas/PaymentTransactionAuto"
                                 }
                             }
                         },
@@ -1434,6 +1551,7 @@
         "/api/v1/payments/{id}/": {
             "get": {
                 "operationId": "payments_retrieve",
+                "description": "Viewset for payment transactions.",
                 "parameters": [
                     {
                         "in": "path",
@@ -1461,7 +1579,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaymentTransaction"
+                                    "$ref": "#/components/schemas/PaymentTransactionAuto"
                                 }
                             }
                         },
@@ -1471,6 +1589,7 @@
             },
             "put": {
                 "operationId": "payments_update",
+                "description": "Viewset for payment transactions.",
                 "parameters": [
                     {
                         "in": "path",
@@ -1489,17 +1608,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PaymentTransactionRequest"
+                                "$ref": "#/components/schemas/PaymentTransactionAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/PaymentTransactionRequest"
+                                "$ref": "#/components/schemas/PaymentTransactionAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/PaymentTransactionRequest"
+                                "$ref": "#/components/schemas/PaymentTransactionAutoRequest"
                             }
                         }
                     },
@@ -1518,7 +1637,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaymentTransaction"
+                                    "$ref": "#/components/schemas/PaymentTransactionAuto"
                                 }
                             }
                         },
@@ -1528,6 +1647,7 @@
             },
             "patch": {
                 "operationId": "payments_partial_update",
+                "description": "Viewset for payment transactions.",
                 "parameters": [
                     {
                         "in": "path",
@@ -1546,17 +1666,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedPaymentTransactionRequest"
+                                "$ref": "#/components/schemas/PatchedPaymentTransactionAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedPaymentTransactionRequest"
+                                "$ref": "#/components/schemas/PatchedPaymentTransactionAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedPaymentTransactionRequest"
+                                "$ref": "#/components/schemas/PatchedPaymentTransactionAutoRequest"
                             }
                         }
                     }
@@ -1574,7 +1694,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaymentTransaction"
+                                    "$ref": "#/components/schemas/PaymentTransactionAuto"
                                 }
                             }
                         },
@@ -1584,6 +1704,7 @@
             },
             "delete": {
                 "operationId": "payments_destroy",
+                "description": "Viewset for payment transactions.",
                 "parameters": [
                     {
                         "in": "path",
@@ -1616,6 +1737,7 @@
         "/api/v1/payments/{id}/capture/": {
             "post": {
                 "operationId": "payments_capture_create",
+                "description": "Viewset for payment transactions.",
                 "parameters": [
                     {
                         "in": "path",
@@ -1634,17 +1756,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PaymentTransactionRequest"
+                                "$ref": "#/components/schemas/PaymentTransactionAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/PaymentTransactionRequest"
+                                "$ref": "#/components/schemas/PaymentTransactionAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/PaymentTransactionRequest"
+                                "$ref": "#/components/schemas/PaymentTransactionAutoRequest"
                             }
                         }
                     },
@@ -1663,7 +1785,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaymentTransaction"
+                                    "$ref": "#/components/schemas/PaymentTransactionAuto"
                                 }
                             }
                         },
@@ -1675,6 +1797,7 @@
         "/api/v1/services/": {
             "get": {
                 "operationId": "services_list",
+                "description": "Viewset for services offered by businesses.",
                 "parameters": [
                     {
                         "name": "ordering",
@@ -1729,7 +1852,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaginatedServiceList"
+                                    "$ref": "#/components/schemas/PaginatedServiceAutoList"
                                 }
                             }
                         },
@@ -1739,6 +1862,7 @@
             },
             "post": {
                 "operationId": "services_create",
+                "description": "Viewset for services offered by businesses.",
                 "tags": [
                     "services"
                 ],
@@ -1746,17 +1870,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/ServiceRequest"
+                                "$ref": "#/components/schemas/ServiceAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/ServiceRequest"
+                                "$ref": "#/components/schemas/ServiceAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/ServiceRequest"
+                                "$ref": "#/components/schemas/ServiceAutoRequest"
                             }
                         }
                     },
@@ -1775,7 +1899,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Service"
+                                    "$ref": "#/components/schemas/ServiceAuto"
                                 }
                             }
                         },
@@ -1787,14 +1911,14 @@
         "/api/v1/services/{id}/": {
             "get": {
                 "operationId": "services_retrieve",
+                "description": "Viewset for services offered by businesses.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this service.",
                         "required": true
                     }
                 ],
@@ -1814,7 +1938,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Service"
+                                    "$ref": "#/components/schemas/ServiceAuto"
                                 }
                             }
                         },
@@ -1824,14 +1948,14 @@
             },
             "put": {
                 "operationId": "services_update",
+                "description": "Viewset for services offered by businesses.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this service.",
                         "required": true
                     }
                 ],
@@ -1842,17 +1966,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/ServiceRequest"
+                                "$ref": "#/components/schemas/ServiceAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/ServiceRequest"
+                                "$ref": "#/components/schemas/ServiceAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/ServiceRequest"
+                                "$ref": "#/components/schemas/ServiceAutoRequest"
                             }
                         }
                     },
@@ -1871,7 +1995,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Service"
+                                    "$ref": "#/components/schemas/ServiceAuto"
                                 }
                             }
                         },
@@ -1881,14 +2005,14 @@
             },
             "patch": {
                 "operationId": "services_partial_update",
+                "description": "Viewset for services offered by businesses.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this service.",
                         "required": true
                     }
                 ],
@@ -1899,17 +2023,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedServiceRequest"
+                                "$ref": "#/components/schemas/PatchedServiceAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedServiceRequest"
+                                "$ref": "#/components/schemas/PatchedServiceAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedServiceRequest"
+                                "$ref": "#/components/schemas/PatchedServiceAutoRequest"
                             }
                         }
                     }
@@ -1927,7 +2051,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Service"
+                                    "$ref": "#/components/schemas/ServiceAuto"
                                 }
                             }
                         },
@@ -1937,14 +2061,14 @@
             },
             "delete": {
                 "operationId": "services_destroy",
+                "description": "Viewset for services offered by businesses.",
                 "parameters": [
                     {
                         "in": "path",
                         "name": "id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string"
                         },
-                        "description": "A unique integer value identifying this service.",
                         "required": true
                     }
                 ],
@@ -1969,7 +2093,44 @@
         "/api/v1/users/": {
             "get": {
                 "operationId": "users_list",
+                "description": "Viewset for user accounts.",
                 "parameters": [
+                    {
+                        "in": "query",
+                        "name": "created_at",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "email",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "full_name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "is_active",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
                     {
                         "name": "ordering",
                         "required": false,
@@ -2005,6 +2166,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "updated_at",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
                     }
                 ],
                 "tags": [
@@ -2023,7 +2192,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaginatedUserList"
+                                    "$ref": "#/components/schemas/PaginatedUserAutoList"
                                 }
                             }
                         },
@@ -2033,6 +2202,7 @@
             },
             "post": {
                 "operationId": "users_create",
+                "description": "Viewset for user accounts.",
                 "tags": [
                     "users"
                 ],
@@ -2040,17 +2210,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/UserRequest"
+                                "$ref": "#/components/schemas/UserAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/UserRequest"
+                                "$ref": "#/components/schemas/UserAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/UserRequest"
+                                "$ref": "#/components/schemas/UserAutoRequest"
                             }
                         }
                     },
@@ -2069,7 +2239,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/User"
+                                    "$ref": "#/components/schemas/UserAuto"
                                 }
                             }
                         },
@@ -2081,6 +2251,7 @@
         "/api/v1/users/{id}/": {
             "get": {
                 "operationId": "users_retrieve",
+                "description": "Viewset for user accounts.",
                 "parameters": [
                     {
                         "in": "path",
@@ -2108,7 +2279,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/User"
+                                    "$ref": "#/components/schemas/UserAuto"
                                 }
                             }
                         },
@@ -2118,6 +2289,7 @@
             },
             "put": {
                 "operationId": "users_update",
+                "description": "Viewset for user accounts.",
                 "parameters": [
                     {
                         "in": "path",
@@ -2136,17 +2308,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/UserRequest"
+                                "$ref": "#/components/schemas/UserAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/UserRequest"
+                                "$ref": "#/components/schemas/UserAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/UserRequest"
+                                "$ref": "#/components/schemas/UserAutoRequest"
                             }
                         }
                     },
@@ -2165,7 +2337,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/User"
+                                    "$ref": "#/components/schemas/UserAuto"
                                 }
                             }
                         },
@@ -2175,6 +2347,7 @@
             },
             "patch": {
                 "operationId": "users_partial_update",
+                "description": "Viewset for user accounts.",
                 "parameters": [
                     {
                         "in": "path",
@@ -2193,17 +2366,17 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedUserRequest"
+                                "$ref": "#/components/schemas/PatchedUserAutoRequest"
                             }
                         },
                         "application/x-www-form-urlencoded": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedUserRequest"
+                                "$ref": "#/components/schemas/PatchedUserAutoRequest"
                             }
                         },
                         "multipart/form-data": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchedUserRequest"
+                                "$ref": "#/components/schemas/PatchedUserAutoRequest"
                             }
                         }
                     }
@@ -2221,7 +2394,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/User"
+                                    "$ref": "#/components/schemas/UserAuto"
                                 }
                             }
                         },
@@ -2231,6 +2404,7 @@
             },
             "delete": {
                 "operationId": "users_destroy",
+                "description": "Viewset for user accounts.",
                 "parameters": [
                     {
                         "in": "path",
@@ -2263,7 +2437,7 @@
     },
     "components": {
         "schemas": {
-            "Appointment": {
+            "AppointmentAuto": {
                 "type": "object",
                 "properties": {
                     "id": {
@@ -2311,7 +2485,7 @@
                     "updated_at"
                 ]
             },
-            "AppointmentRequest": {
+            "AppointmentAutoRequest": {
                 "type": "object",
                 "properties": {
                     "customer": {
@@ -2343,7 +2517,7 @@
                     "service"
                 ]
             },
-            "BusinessProfile": {
+            "BusinessProfileAuto": {
                 "type": "object",
                 "properties": {
                     "id": {
@@ -2351,7 +2525,8 @@
                         "readOnly": true
                     },
                     "owner": {
-                        "type": "integer"
+                        "type": "integer",
+                        "readOnly": true
                     },
                     "name": {
                         "type": "string",
@@ -2379,12 +2554,9 @@
                     "updated_at"
                 ]
             },
-            "BusinessProfileRequest": {
+            "BusinessProfileAutoRequest": {
                 "type": "object",
                 "properties": {
-                    "owner": {
-                        "type": "integer"
-                    },
                     "name": {
                         "type": "string",
                         "minLength": 1,
@@ -2395,11 +2567,10 @@
                     }
                 },
                 "required": [
-                    "name",
-                    "owner"
+                    "name"
                 ]
             },
-            "Listing": {
+            "ListingAuto": {
                 "type": "object",
                 "properties": {
                     "id": {
@@ -2440,7 +2611,7 @@
                     "updated_at"
                 ]
             },
-            "ListingRequest": {
+            "ListingAutoRequest": {
                 "type": "object",
                 "properties": {
                     "business": {
@@ -2464,7 +2635,7 @@
                     "service"
                 ]
             },
-            "Notification": {
+            "NotificationAuto": {
                 "type": "object",
                 "properties": {
                     "id": {
@@ -2508,7 +2679,7 @@
                     "updated_at"
                 ]
             },
-            "NotificationRequest": {
+            "NotificationAutoRequest": {
                 "type": "object",
                 "properties": {
                     "recipient": {
@@ -2530,7 +2701,7 @@
                     "subject"
                 ]
             },
-            "PaginatedAppointmentList": {
+            "PaginatedAppointmentAutoList": {
                 "type": "object",
                 "required": [
                     "count",
@@ -2556,12 +2727,12 @@
                     "results": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/Appointment"
+                            "$ref": "#/components/schemas/AppointmentAuto"
                         }
                     }
                 }
             },
-            "PaginatedBusinessProfileList": {
+            "PaginatedBusinessProfileAutoList": {
                 "type": "object",
                 "required": [
                     "count",
@@ -2587,12 +2758,12 @@
                     "results": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/BusinessProfile"
+                            "$ref": "#/components/schemas/BusinessProfileAuto"
                         }
                     }
                 }
             },
-            "PaginatedListingList": {
+            "PaginatedListingAutoList": {
                 "type": "object",
                 "required": [
                     "count",
@@ -2618,12 +2789,12 @@
                     "results": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/Listing"
+                            "$ref": "#/components/schemas/ListingAuto"
                         }
                     }
                 }
             },
-            "PaginatedNotificationList": {
+            "PaginatedNotificationAutoList": {
                 "type": "object",
                 "required": [
                     "count",
@@ -2649,12 +2820,12 @@
                     "results": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/Notification"
+                            "$ref": "#/components/schemas/NotificationAuto"
                         }
                     }
                 }
             },
-            "PaginatedPaymentTransactionList": {
+            "PaginatedPaymentTransactionAutoList": {
                 "type": "object",
                 "required": [
                     "count",
@@ -2680,12 +2851,12 @@
                     "results": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/PaymentTransaction"
+                            "$ref": "#/components/schemas/PaymentTransactionAuto"
                         }
                     }
                 }
             },
-            "PaginatedServiceList": {
+            "PaginatedServiceAutoList": {
                 "type": "object",
                 "required": [
                     "count",
@@ -2711,12 +2882,12 @@
                     "results": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/Service"
+                            "$ref": "#/components/schemas/ServiceAuto"
                         }
                     }
                 }
             },
-            "PaginatedUserList": {
+            "PaginatedUserAutoList": {
                 "type": "object",
                 "required": [
                     "count",
@@ -2742,12 +2913,12 @@
                     "results": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/User"
+                            "$ref": "#/components/schemas/UserAuto"
                         }
                     }
                 }
             },
-            "PatchedAppointmentRequest": {
+            "PatchedAppointmentAutoRequest": {
                 "type": "object",
                 "properties": {
                     "customer": {
@@ -2773,12 +2944,9 @@
                     }
                 }
             },
-            "PatchedBusinessProfileRequest": {
+            "PatchedBusinessProfileAutoRequest": {
                 "type": "object",
                 "properties": {
-                    "owner": {
-                        "type": "integer"
-                    },
                     "name": {
                         "type": "string",
                         "minLength": 1,
@@ -2789,7 +2957,7 @@
                     }
                 }
             },
-            "PatchedListingRequest": {
+            "PatchedListingAutoRequest": {
                 "type": "object",
                 "properties": {
                     "business": {
@@ -2808,7 +2976,7 @@
                     }
                 }
             },
-            "PatchedNotificationRequest": {
+            "PatchedNotificationAutoRequest": {
                 "type": "object",
                 "properties": {
                     "recipient": {
@@ -2825,7 +2993,7 @@
                     }
                 }
             },
-            "PatchedPaymentTransactionRequest": {
+            "PatchedPaymentTransactionAutoRequest": {
                 "type": "object",
                 "properties": {
                     "appointment": {
@@ -2843,7 +3011,7 @@
                     }
                 }
             },
-            "PatchedServiceRequest": {
+            "PatchedServiceAutoRequest": {
                 "type": "object",
                 "properties": {
                     "business": {
@@ -2858,11 +3026,14 @@
                         "type": "string"
                     },
                     "duration_minutes": {
-                        "type": "integer"
+                        "type": "integer",
+                        "maximum": 9223372036854775807,
+                        "minimum": 0,
+                        "format": "int64"
                     }
                 }
             },
-            "PatchedUserRequest": {
+            "PatchedUserAutoRequest": {
                 "type": "object",
                 "properties": {
                     "email": {
@@ -2877,7 +3048,7 @@
                     }
                 }
             },
-            "PaymentTransaction": {
+            "PaymentTransactionAuto": {
                 "type": "object",
                 "properties": {
                     "id": {
@@ -2925,7 +3096,7 @@
                     "updated_at"
                 ]
             },
-            "PaymentTransactionRequest": {
+            "PaymentTransactionAutoRequest": {
                 "type": "object",
                 "properties": {
                     "appointment": {
@@ -2947,7 +3118,7 @@
                     "appointment"
                 ]
             },
-            "Service": {
+            "ServiceAuto": {
                 "type": "object",
                 "properties": {
                     "id": {
@@ -2965,7 +3136,10 @@
                         "type": "string"
                     },
                     "duration_minutes": {
-                        "type": "integer"
+                        "type": "integer",
+                        "maximum": 9223372036854775807,
+                        "minimum": 0,
+                        "format": "int64"
                     },
                     "created_at": {
                         "type": "string",
@@ -2986,7 +3160,7 @@
                     "updated_at"
                 ]
             },
-            "ServiceRequest": {
+            "ServiceAutoRequest": {
                 "type": "object",
                 "properties": {
                     "business": {
@@ -3001,7 +3175,10 @@
                         "type": "string"
                     },
                     "duration_minutes": {
-                        "type": "integer"
+                        "type": "integer",
+                        "maximum": 9223372036854775807,
+                        "minimum": 0,
+                        "format": "int64"
                     }
                 },
                 "required": [
@@ -3073,7 +3250,7 @@
                     "refresh"
                 ]
             },
-            "User": {
+            "UserAuto": {
                 "type": "object",
                 "properties": {
                     "id": {
@@ -3112,7 +3289,7 @@
                     "updated_at"
                 ]
             },
-            "UserRequest": {
+            "UserAutoRequest": {
                 "type": "object",
                 "properties": {
                     "email": {

--- a/backend/api/schema/openapi.yaml
+++ b/backend/api/schema/openapi.yaml
@@ -12,9 +12,10 @@ paths:
   /api/auth/jwt/create/:
     post:
       operationId: api_auth_jwt_create_create
-      description: |-
-        Takes a set of user credentials and returns an access and refresh JSON web
-        token pair to prove the authentication of those credentials.
+      description: 'Takes a set of user credentials and returns an access and refresh
+        JSON web
+
+        token pair to prove the authentication of those credentials.'
       tags:
       - api
       requestBody:
@@ -39,9 +40,10 @@ paths:
   /api/auth/jwt/refresh/:
     post:
       operationId: api_auth_jwt_refresh_create
-      description: |-
-        Takes a refresh type JSON web token and returns an access type JSON web
-        token if the refresh token is valid.
+      description: 'Takes a refresh type JSON web token and returns an access type
+        JSON web
+
+        token if the refresh token is valid.'
       tags:
       - api
       requestBody:
@@ -66,6 +68,7 @@ paths:
   /api/v1/appointments/:
     get:
       operationId: appointments_list
+      description: Viewset for appointments.
       parameters:
       - name: ordering
         required: false
@@ -101,23 +104,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedAppointmentList'
+                $ref: '#/components/schemas/PaginatedAppointmentAutoList'
           description: ''
     post:
       operationId: appointments_create
+      description: Viewset for appointments.
       tags:
       - appointments
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AppointmentRequest'
+              $ref: '#/components/schemas/AppointmentAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/AppointmentRequest'
+              $ref: '#/components/schemas/AppointmentAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/AppointmentRequest'
+              $ref: '#/components/schemas/AppointmentAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -127,17 +131,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Appointment'
+                $ref: '#/components/schemas/AppointmentAuto'
           description: ''
   /api/v1/appointments/{id}/:
     get:
       operationId: appointments_retrieve
+      description: Viewset for appointments.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this appointment.
+          type: string
         required: true
       tags:
       - appointments
@@ -149,16 +153,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Appointment'
+                $ref: '#/components/schemas/AppointmentAuto'
           description: ''
     put:
       operationId: appointments_update
+      description: Viewset for appointments.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this appointment.
+          type: string
         required: true
       tags:
       - appointments
@@ -166,13 +170,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AppointmentRequest'
+              $ref: '#/components/schemas/AppointmentAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/AppointmentRequest'
+              $ref: '#/components/schemas/AppointmentAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/AppointmentRequest'
+              $ref: '#/components/schemas/AppointmentAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -182,16 +186,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Appointment'
+                $ref: '#/components/schemas/AppointmentAuto'
           description: ''
     patch:
       operationId: appointments_partial_update
+      description: Viewset for appointments.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this appointment.
+          type: string
         required: true
       tags:
       - appointments
@@ -199,13 +203,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedAppointmentRequest'
+              $ref: '#/components/schemas/PatchedAppointmentAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedAppointmentRequest'
+              $ref: '#/components/schemas/PatchedAppointmentAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedAppointmentRequest'
+              $ref: '#/components/schemas/PatchedAppointmentAutoRequest'
       security:
       - cookieAuth: []
       - jwtAuth: []
@@ -214,16 +218,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Appointment'
+                $ref: '#/components/schemas/AppointmentAuto'
           description: ''
     delete:
       operationId: appointments_destroy
+      description: Viewset for appointments.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this appointment.
+          type: string
         required: true
       tags:
       - appointments
@@ -236,13 +240,35 @@ paths:
   /api/v1/businesses/:
     get:
       operationId: businesses_list
+      description: Viewset for business profiles.
       parameters:
+      - in: query
+        name: created_at
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: description
+        schema:
+          type: string
+      - in: query
+        name: id
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
       - name: ordering
         required: false
         in: query
         description: Which field to use when ordering the results.
         schema:
           type: string
+      - in: query
+        name: owner
+        schema:
+          type: integer
       - name: page
         required: false
         in: query
@@ -261,6 +287,11 @@ paths:
         description: A search term.
         schema:
           type: string
+      - in: query
+        name: updated_at
+        schema:
+          type: string
+          format: date-time
       tags:
       - businesses
       security:
@@ -271,23 +302,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedBusinessProfileList'
+                $ref: '#/components/schemas/PaginatedBusinessProfileAutoList'
           description: ''
     post:
       operationId: businesses_create
+      description: Viewset for business profiles.
       tags:
       - businesses
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BusinessProfileRequest'
+              $ref: '#/components/schemas/BusinessProfileAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/BusinessProfileRequest'
+              $ref: '#/components/schemas/BusinessProfileAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/BusinessProfileRequest'
+              $ref: '#/components/schemas/BusinessProfileAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -297,11 +329,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BusinessProfile'
+                $ref: '#/components/schemas/BusinessProfileAuto'
           description: ''
   /api/v1/businesses/{id}/:
     get:
       operationId: businesses_retrieve
+      description: Viewset for business profiles.
       parameters:
       - in: path
         name: id
@@ -319,10 +352,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BusinessProfile'
+                $ref: '#/components/schemas/BusinessProfileAuto'
           description: ''
     put:
       operationId: businesses_update
+      description: Viewset for business profiles.
       parameters:
       - in: path
         name: id
@@ -336,13 +370,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BusinessProfileRequest'
+              $ref: '#/components/schemas/BusinessProfileAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/BusinessProfileRequest'
+              $ref: '#/components/schemas/BusinessProfileAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/BusinessProfileRequest'
+              $ref: '#/components/schemas/BusinessProfileAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -352,10 +386,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BusinessProfile'
+                $ref: '#/components/schemas/BusinessProfileAuto'
           description: ''
     patch:
       operationId: businesses_partial_update
+      description: Viewset for business profiles.
       parameters:
       - in: path
         name: id
@@ -369,13 +404,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedBusinessProfileRequest'
+              $ref: '#/components/schemas/PatchedBusinessProfileAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedBusinessProfileRequest'
+              $ref: '#/components/schemas/PatchedBusinessProfileAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedBusinessProfileRequest'
+              $ref: '#/components/schemas/PatchedBusinessProfileAutoRequest'
       security:
       - cookieAuth: []
       - jwtAuth: []
@@ -384,10 +419,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BusinessProfile'
+                $ref: '#/components/schemas/BusinessProfileAuto'
           description: ''
     delete:
       operationId: businesses_destroy
+      description: Viewset for business profiles.
       parameters:
       - in: path
         name: id
@@ -406,6 +442,7 @@ paths:
   /api/v1/listings/:
     get:
       operationId: listings_list
+      description: Viewset for marketplace listings.
       parameters:
       - name: ordering
         required: false
@@ -441,23 +478,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedListingList'
+                $ref: '#/components/schemas/PaginatedListingAutoList'
           description: ''
     post:
       operationId: listings_create
+      description: Viewset for marketplace listings.
       tags:
       - listings
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ListingRequest'
+              $ref: '#/components/schemas/ListingAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ListingRequest'
+              $ref: '#/components/schemas/ListingAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ListingRequest'
+              $ref: '#/components/schemas/ListingAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -467,17 +505,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Listing'
+                $ref: '#/components/schemas/ListingAuto'
           description: ''
   /api/v1/listings/{id}/:
     get:
       operationId: listings_retrieve
+      description: Viewset for marketplace listings.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this listing.
+          type: string
         required: true
       tags:
       - listings
@@ -489,16 +527,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Listing'
+                $ref: '#/components/schemas/ListingAuto'
           description: ''
     put:
       operationId: listings_update
+      description: Viewset for marketplace listings.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this listing.
+          type: string
         required: true
       tags:
       - listings
@@ -506,13 +544,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ListingRequest'
+              $ref: '#/components/schemas/ListingAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ListingRequest'
+              $ref: '#/components/schemas/ListingAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ListingRequest'
+              $ref: '#/components/schemas/ListingAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -522,16 +560,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Listing'
+                $ref: '#/components/schemas/ListingAuto'
           description: ''
     patch:
       operationId: listings_partial_update
+      description: Viewset for marketplace listings.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this listing.
+          type: string
         required: true
       tags:
       - listings
@@ -539,13 +577,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedListingRequest'
+              $ref: '#/components/schemas/PatchedListingAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedListingRequest'
+              $ref: '#/components/schemas/PatchedListingAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedListingRequest'
+              $ref: '#/components/schemas/PatchedListingAutoRequest'
       security:
       - cookieAuth: []
       - jwtAuth: []
@@ -554,16 +592,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Listing'
+                $ref: '#/components/schemas/ListingAuto'
           description: ''
     delete:
       operationId: listings_destroy
+      description: Viewset for marketplace listings.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this listing.
+          type: string
         required: true
       tags:
       - listings
@@ -576,6 +614,7 @@ paths:
   /api/v1/notifications/:
     get:
       operationId: notifications_list
+      description: Viewset for user notifications.
       parameters:
       - name: ordering
         required: false
@@ -611,23 +650,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedNotificationList'
+                $ref: '#/components/schemas/PaginatedNotificationAutoList'
           description: ''
     post:
       operationId: notifications_create
+      description: Viewset for user notifications.
       tags:
       - notifications
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationRequest'
+              $ref: '#/components/schemas/NotificationAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/NotificationRequest'
+              $ref: '#/components/schemas/NotificationAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/NotificationRequest'
+              $ref: '#/components/schemas/NotificationAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -637,17 +677,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Notification'
+                $ref: '#/components/schemas/NotificationAuto'
           description: ''
   /api/v1/notifications/{id}/:
     get:
       operationId: notifications_retrieve
+      description: Viewset for user notifications.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this notification.
+          type: string
         required: true
       tags:
       - notifications
@@ -659,16 +699,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Notification'
+                $ref: '#/components/schemas/NotificationAuto'
           description: ''
     put:
       operationId: notifications_update
+      description: Viewset for user notifications.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this notification.
+          type: string
         required: true
       tags:
       - notifications
@@ -676,13 +716,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationRequest'
+              $ref: '#/components/schemas/NotificationAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/NotificationRequest'
+              $ref: '#/components/schemas/NotificationAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/NotificationRequest'
+              $ref: '#/components/schemas/NotificationAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -692,16 +732,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Notification'
+                $ref: '#/components/schemas/NotificationAuto'
           description: ''
     patch:
       operationId: notifications_partial_update
+      description: Viewset for user notifications.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this notification.
+          type: string
         required: true
       tags:
       - notifications
@@ -709,13 +749,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedNotificationRequest'
+              $ref: '#/components/schemas/PatchedNotificationAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedNotificationRequest'
+              $ref: '#/components/schemas/PatchedNotificationAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedNotificationRequest'
+              $ref: '#/components/schemas/PatchedNotificationAutoRequest'
       security:
       - cookieAuth: []
       - jwtAuth: []
@@ -724,16 +764,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Notification'
+                $ref: '#/components/schemas/NotificationAuto'
           description: ''
     delete:
       operationId: notifications_destroy
+      description: Viewset for user notifications.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this notification.
+          type: string
         required: true
       tags:
       - notifications
@@ -746,19 +786,20 @@ paths:
   /api/v1/notifications/send-test/:
     post:
       operationId: notifications_send_test_create
+      description: Viewset for user notifications.
       tags:
       - notifications
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NotificationRequest'
+              $ref: '#/components/schemas/NotificationAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/NotificationRequest'
+              $ref: '#/components/schemas/NotificationAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/NotificationRequest'
+              $ref: '#/components/schemas/NotificationAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -768,12 +809,38 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Notification'
+                $ref: '#/components/schemas/NotificationAuto'
           description: ''
   /api/v1/payments/:
     get:
       operationId: payments_list
+      description: Viewset for payment transactions.
       parameters:
+      - in: query
+        name: amount
+        schema:
+          type: number
+      - in: query
+        name: appointment
+        schema:
+          type: integer
+      - in: query
+        name: created_at
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: currency
+        schema:
+          type: string
+      - in: query
+        name: external_reference
+        schema:
+          type: string
+      - in: query
+        name: id
+        schema:
+          type: integer
       - name: ordering
         required: false
         in: query
@@ -798,6 +865,15 @@ paths:
         description: A search term.
         schema:
           type: string
+      - in: query
+        name: status
+        schema:
+          type: string
+      - in: query
+        name: updated_at
+        schema:
+          type: string
+          format: date-time
       tags:
       - payments
       security:
@@ -808,23 +884,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedPaymentTransactionList'
+                $ref: '#/components/schemas/PaginatedPaymentTransactionAutoList'
           description: ''
     post:
       operationId: payments_create
+      description: Viewset for payment transactions.
       tags:
       - payments
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PaymentTransactionRequest'
+              $ref: '#/components/schemas/PaymentTransactionAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PaymentTransactionRequest'
+              $ref: '#/components/schemas/PaymentTransactionAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PaymentTransactionRequest'
+              $ref: '#/components/schemas/PaymentTransactionAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -834,11 +911,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaymentTransaction'
+                $ref: '#/components/schemas/PaymentTransactionAuto'
           description: ''
   /api/v1/payments/{id}/:
     get:
       operationId: payments_retrieve
+      description: Viewset for payment transactions.
       parameters:
       - in: path
         name: id
@@ -856,10 +934,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaymentTransaction'
+                $ref: '#/components/schemas/PaymentTransactionAuto'
           description: ''
     put:
       operationId: payments_update
+      description: Viewset for payment transactions.
       parameters:
       - in: path
         name: id
@@ -873,13 +952,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PaymentTransactionRequest'
+              $ref: '#/components/schemas/PaymentTransactionAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PaymentTransactionRequest'
+              $ref: '#/components/schemas/PaymentTransactionAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PaymentTransactionRequest'
+              $ref: '#/components/schemas/PaymentTransactionAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -889,10 +968,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaymentTransaction'
+                $ref: '#/components/schemas/PaymentTransactionAuto'
           description: ''
     patch:
       operationId: payments_partial_update
+      description: Viewset for payment transactions.
       parameters:
       - in: path
         name: id
@@ -906,13 +986,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedPaymentTransactionRequest'
+              $ref: '#/components/schemas/PatchedPaymentTransactionAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedPaymentTransactionRequest'
+              $ref: '#/components/schemas/PatchedPaymentTransactionAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedPaymentTransactionRequest'
+              $ref: '#/components/schemas/PatchedPaymentTransactionAutoRequest'
       security:
       - cookieAuth: []
       - jwtAuth: []
@@ -921,10 +1001,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaymentTransaction'
+                $ref: '#/components/schemas/PaymentTransactionAuto'
           description: ''
     delete:
       operationId: payments_destroy
+      description: Viewset for payment transactions.
       parameters:
       - in: path
         name: id
@@ -943,6 +1024,7 @@ paths:
   /api/v1/payments/{id}/capture/:
     post:
       operationId: payments_capture_create
+      description: Viewset for payment transactions.
       parameters:
       - in: path
         name: id
@@ -956,13 +1038,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PaymentTransactionRequest'
+              $ref: '#/components/schemas/PaymentTransactionAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PaymentTransactionRequest'
+              $ref: '#/components/schemas/PaymentTransactionAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PaymentTransactionRequest'
+              $ref: '#/components/schemas/PaymentTransactionAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -972,11 +1054,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaymentTransaction'
+                $ref: '#/components/schemas/PaymentTransactionAuto'
           description: ''
   /api/v1/services/:
     get:
       operationId: services_list
+      description: Viewset for services offered by businesses.
       parameters:
       - name: ordering
         required: false
@@ -1012,23 +1095,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedServiceList'
+                $ref: '#/components/schemas/PaginatedServiceAutoList'
           description: ''
     post:
       operationId: services_create
+      description: Viewset for services offered by businesses.
       tags:
       - services
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServiceRequest'
+              $ref: '#/components/schemas/ServiceAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ServiceRequest'
+              $ref: '#/components/schemas/ServiceAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ServiceRequest'
+              $ref: '#/components/schemas/ServiceAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -1038,17 +1122,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Service'
+                $ref: '#/components/schemas/ServiceAuto'
           description: ''
   /api/v1/services/{id}/:
     get:
       operationId: services_retrieve
+      description: Viewset for services offered by businesses.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this service.
+          type: string
         required: true
       tags:
       - services
@@ -1060,16 +1144,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Service'
+                $ref: '#/components/schemas/ServiceAuto'
           description: ''
     put:
       operationId: services_update
+      description: Viewset for services offered by businesses.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this service.
+          type: string
         required: true
       tags:
       - services
@@ -1077,13 +1161,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServiceRequest'
+              $ref: '#/components/schemas/ServiceAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/ServiceRequest'
+              $ref: '#/components/schemas/ServiceAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/ServiceRequest'
+              $ref: '#/components/schemas/ServiceAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -1093,16 +1177,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Service'
+                $ref: '#/components/schemas/ServiceAuto'
           description: ''
     patch:
       operationId: services_partial_update
+      description: Viewset for services offered by businesses.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this service.
+          type: string
         required: true
       tags:
       - services
@@ -1110,13 +1194,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedServiceRequest'
+              $ref: '#/components/schemas/PatchedServiceAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedServiceRequest'
+              $ref: '#/components/schemas/PatchedServiceAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedServiceRequest'
+              $ref: '#/components/schemas/PatchedServiceAutoRequest'
       security:
       - cookieAuth: []
       - jwtAuth: []
@@ -1125,16 +1209,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Service'
+                $ref: '#/components/schemas/ServiceAuto'
           description: ''
     delete:
       operationId: services_destroy
+      description: Viewset for services offered by businesses.
       parameters:
       - in: path
         name: id
         schema:
-          type: integer
-        description: A unique integer value identifying this service.
+          type: string
         required: true
       tags:
       - services
@@ -1147,7 +1231,29 @@ paths:
   /api/v1/users/:
     get:
       operationId: users_list
+      description: Viewset for user accounts.
       parameters:
+      - in: query
+        name: created_at
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: email
+        schema:
+          type: string
+      - in: query
+        name: full_name
+        schema:
+          type: string
+      - in: query
+        name: id
+        schema:
+          type: integer
+      - in: query
+        name: is_active
+        schema:
+          type: boolean
       - name: ordering
         required: false
         in: query
@@ -1172,6 +1278,11 @@ paths:
         description: A search term.
         schema:
           type: string
+      - in: query
+        name: updated_at
+        schema:
+          type: string
+          format: date-time
       tags:
       - users
       security:
@@ -1182,23 +1293,24 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedUserList'
+                $ref: '#/components/schemas/PaginatedUserAutoList'
           description: ''
     post:
       operationId: users_create
+      description: Viewset for user accounts.
       tags:
       - users
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserRequest'
+              $ref: '#/components/schemas/UserAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/UserRequest'
+              $ref: '#/components/schemas/UserAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/UserRequest'
+              $ref: '#/components/schemas/UserAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -1208,11 +1320,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/UserAuto'
           description: ''
   /api/v1/users/{id}/:
     get:
       operationId: users_retrieve
+      description: Viewset for user accounts.
       parameters:
       - in: path
         name: id
@@ -1230,10 +1343,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/UserAuto'
           description: ''
     put:
       operationId: users_update
+      description: Viewset for user accounts.
       parameters:
       - in: path
         name: id
@@ -1247,13 +1361,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UserRequest'
+              $ref: '#/components/schemas/UserAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/UserRequest'
+              $ref: '#/components/schemas/UserAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/UserRequest'
+              $ref: '#/components/schemas/UserAutoRequest'
         required: true
       security:
       - cookieAuth: []
@@ -1263,10 +1377,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/UserAuto'
           description: ''
     patch:
       operationId: users_partial_update
+      description: Viewset for user accounts.
       parameters:
       - in: path
         name: id
@@ -1280,13 +1395,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedUserRequest'
+              $ref: '#/components/schemas/PatchedUserAutoRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedUserRequest'
+              $ref: '#/components/schemas/PatchedUserAutoRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedUserRequest'
+              $ref: '#/components/schemas/PatchedUserAutoRequest'
       security:
       - cookieAuth: []
       - jwtAuth: []
@@ -1295,10 +1410,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/UserAuto'
           description: ''
     delete:
       operationId: users_destroy
+      description: Viewset for user accounts.
       parameters:
       - in: path
         name: id
@@ -1316,7 +1432,7 @@ paths:
           description: No response body
 components:
   schemas:
-    Appointment:
+    AppointmentAuto:
       type: object
       properties:
         id:
@@ -1352,7 +1468,7 @@ components:
       - scheduled_for
       - service
       - updated_at
-    AppointmentRequest:
+    AppointmentAutoRequest:
       type: object
       properties:
         customer:
@@ -1375,7 +1491,7 @@ components:
       - customer
       - scheduled_for
       - service
-    BusinessProfile:
+    BusinessProfileAuto:
       type: object
       properties:
         id:
@@ -1383,6 +1499,7 @@ components:
           readOnly: true
         owner:
           type: integer
+          readOnly: true
         name:
           type: string
           maxLength: 255
@@ -1402,11 +1519,9 @@ components:
       - name
       - owner
       - updated_at
-    BusinessProfileRequest:
+    BusinessProfileAutoRequest:
       type: object
       properties:
-        owner:
-          type: integer
         name:
           type: string
           minLength: 1
@@ -1415,8 +1530,7 @@ components:
           type: string
       required:
       - name
-      - owner
-    Listing:
+    ListingAuto:
       type: object
       properties:
         id:
@@ -1447,7 +1561,7 @@ components:
       - price
       - service
       - updated_at
-    ListingRequest:
+    ListingAutoRequest:
       type: object
       properties:
         business:
@@ -1464,7 +1578,7 @@ components:
       - business
       - price
       - service
-    Notification:
+    NotificationAuto:
       type: object
       properties:
         id:
@@ -1498,7 +1612,7 @@ components:
       - recipient
       - subject
       - updated_at
-    NotificationRequest:
+    NotificationAutoRequest:
       type: object
       properties:
         recipient:
@@ -1514,7 +1628,7 @@ components:
       - body
       - recipient
       - subject
-    PaginatedAppointmentList:
+    PaginatedAppointmentAutoList:
       type: object
       required:
       - count
@@ -1536,8 +1650,8 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Appointment'
-    PaginatedBusinessProfileList:
+            $ref: '#/components/schemas/AppointmentAuto'
+    PaginatedBusinessProfileAutoList:
       type: object
       required:
       - count
@@ -1559,8 +1673,8 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/BusinessProfile'
-    PaginatedListingList:
+            $ref: '#/components/schemas/BusinessProfileAuto'
+    PaginatedListingAutoList:
       type: object
       required:
       - count
@@ -1582,8 +1696,8 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Listing'
-    PaginatedNotificationList:
+            $ref: '#/components/schemas/ListingAuto'
+    PaginatedNotificationAutoList:
       type: object
       required:
       - count
@@ -1605,8 +1719,8 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Notification'
-    PaginatedPaymentTransactionList:
+            $ref: '#/components/schemas/NotificationAuto'
+    PaginatedPaymentTransactionAutoList:
       type: object
       required:
       - count
@@ -1628,8 +1742,8 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/PaymentTransaction'
-    PaginatedServiceList:
+            $ref: '#/components/schemas/PaymentTransactionAuto'
+    PaginatedServiceAutoList:
       type: object
       required:
       - count
@@ -1651,8 +1765,8 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/Service'
-    PaginatedUserList:
+            $ref: '#/components/schemas/ServiceAuto'
+    PaginatedUserAutoList:
       type: object
       required:
       - count
@@ -1674,8 +1788,8 @@ components:
         results:
           type: array
           items:
-            $ref: '#/components/schemas/User'
-    PatchedAppointmentRequest:
+            $ref: '#/components/schemas/UserAuto'
+    PatchedAppointmentAutoRequest:
       type: object
       properties:
         customer:
@@ -1693,18 +1807,16 @@ components:
           maxLength: 50
         notes:
           type: string
-    PatchedBusinessProfileRequest:
+    PatchedBusinessProfileAutoRequest:
       type: object
       properties:
-        owner:
-          type: integer
         name:
           type: string
           minLength: 1
           maxLength: 255
         description:
           type: string
-    PatchedListingRequest:
+    PatchedListingAutoRequest:
       type: object
       properties:
         business:
@@ -1717,7 +1829,7 @@ components:
           pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
         is_active:
           type: boolean
-    PatchedNotificationRequest:
+    PatchedNotificationAutoRequest:
       type: object
       properties:
         recipient:
@@ -1729,7 +1841,7 @@ components:
         body:
           type: string
           minLength: 1
-    PatchedPaymentTransactionRequest:
+    PatchedPaymentTransactionAutoRequest:
       type: object
       properties:
         appointment:
@@ -1742,7 +1854,7 @@ components:
           type: string
           minLength: 1
           maxLength: 10
-    PatchedServiceRequest:
+    PatchedServiceAutoRequest:
       type: object
       properties:
         business:
@@ -1755,7 +1867,10 @@ components:
           type: string
         duration_minutes:
           type: integer
-    PatchedUserRequest:
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
+    PatchedUserAutoRequest:
       type: object
       properties:
         email:
@@ -1766,7 +1881,7 @@ components:
         full_name:
           type: string
           maxLength: 255
-    PaymentTransaction:
+    PaymentTransactionAuto:
       type: object
       properties:
         id:
@@ -1803,7 +1918,7 @@ components:
       - id
       - status
       - updated_at
-    PaymentTransactionRequest:
+    PaymentTransactionAutoRequest:
       type: object
       properties:
         appointment:
@@ -1819,7 +1934,7 @@ components:
       required:
       - amount
       - appointment
-    Service:
+    ServiceAuto:
       type: object
       properties:
         id:
@@ -1834,6 +1949,9 @@ components:
           type: string
         duration_minutes:
           type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
         created_at:
           type: string
           format: date-time
@@ -1848,7 +1966,7 @@ components:
       - id
       - name
       - updated_at
-    ServiceRequest:
+    ServiceAutoRequest:
       type: object
       properties:
         business:
@@ -1861,6 +1979,9 @@ components:
           type: string
         duration_minutes:
           type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+          format: int64
       required:
       - business
       - name
@@ -1909,7 +2030,7 @@ components:
           minLength: 1
       required:
       - refresh
-    User:
+    UserAuto:
       type: object
       properties:
         id:
@@ -1939,7 +2060,7 @@ components:
       - id
       - is_active
       - updated_at
-    UserRequest:
+    UserAutoRequest:
       type: object
       properties:
         email:

--- a/backend/api/schema/openapi.yaml
+++ b/backend/api/schema/openapi.yaml
@@ -12,10 +12,9 @@ paths:
   /api/auth/jwt/create/:
     post:
       operationId: api_auth_jwt_create_create
-      description: 'Takes a set of user credentials and returns an access and refresh
-        JSON web
-
-        token pair to prove the authentication of those credentials.'
+      description: |-
+        Takes a set of user credentials and returns an access and refresh JSON web
+        token pair to prove the authentication of those credentials.
       tags:
       - api
       requestBody:
@@ -40,10 +39,9 @@ paths:
   /api/auth/jwt/refresh/:
     post:
       operationId: api_auth_jwt_refresh_create
-      description: 'Takes a refresh type JSON web token and returns an access type
-        JSON web
-
-        token if the refresh token is valid.'
+      description: |-
+        Takes a refresh type JSON web token and returns an access type JSON web
+        token if the refresh token is valid.
       tags:
       - api
       requestBody:

--- a/backend/api/tests/__init__.py
+++ b/backend/api/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the public API package."""

--- a/backend/api/tests/test_api_crud.py
+++ b/backend/api/tests/test_api_crud.py
@@ -1,0 +1,99 @@
+"""End-to-end CRUD tests for public API resources."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.urls import reverse
+
+from business.models import BusinessProfile
+from marketplace.models import Listing
+from services.models import Service
+
+
+@pytest.fixture
+def owner(user_factory):
+    """Return a user that owns the seeded business."""
+
+    return user_factory(email="owner-crud@example.com")
+
+
+@pytest.fixture
+def business(owner):
+    """Create a business profile owned by the authenticated user."""
+
+    return BusinessProfile.objects.create(
+        owner=owner,
+        name="Integration Business",
+        description="Business generated for API CRUD tests.",
+    )
+
+
+@pytest.fixture
+def service(business):
+    """Create a service offered by the seeded business."""
+
+    return Service.objects.create(
+        business=business,
+        name="Consultation",
+        description="Standard consultation service.",
+        duration_minutes=45,
+    )
+
+
+@pytest.mark.django_db
+def test_listing_crud_lifecycle(api_client, owner, business, service):
+    """Ensure listings can be created, read, updated and deleted."""
+
+    api_client.force_authenticate(owner)
+
+    list_url = reverse("api:listings-list")
+    create_payload = {
+        "business": business.pk,
+        "service": service.pk,
+        "price": "79.99",
+        "is_active": True,
+    }
+
+    create_response = api_client.post(list_url, data=create_payload, format="json")
+    assert create_response.status_code == 201
+    created = create_response.json()
+    listing_id = created["id"]
+
+    detail_url = reverse("api:listings-detail", args=[listing_id])
+    retrieve_response = api_client.get(detail_url)
+    assert retrieve_response.status_code == 200
+    retrieved = retrieve_response.json()
+    assert retrieved["business"] == business.pk
+    assert retrieved["service"] == service.pk
+    assert Decimal(str(retrieved["price"])) == Decimal("79.99")
+    assert retrieved["is_active"] is True
+
+    patch_payload = {"price": "59.50", "is_active": False}
+    update_response = api_client.patch(detail_url, data=patch_payload, format="json")
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert Decimal(str(updated["price"])) == Decimal("59.50")
+    assert updated["is_active"] is False
+
+    list_response = api_client.get(list_url)
+    assert list_response.status_code == 200
+    payload = list_response.json()
+    results = payload.get("results", payload)
+    assert any(item["id"] == listing_id for item in results)
+
+    delete_response = api_client.delete(detail_url)
+    assert delete_response.status_code == 204
+    assert not Listing.objects.filter(pk=listing_id).exists()
+
+
+@pytest.mark.django_db
+def test_listing_requires_authentication(api_client):
+    """Anonymous users should be rejected when accessing protected endpoints."""
+
+    response = api_client.get(reverse("api:listings-list"))
+
+    assert response.status_code in {401, 403}
+    payload = response.json()
+    assert payload.get("detail")

--- a/backend/api/tests/test_api_crud.py
+++ b/backend/api/tests/test_api_crud.py
@@ -11,6 +11,8 @@ from business.models import BusinessProfile
 from marketplace.models import Listing
 from services.models import Service
 
+from backend.tests.utils import extract_results
+
 
 @pytest.fixture
 def owner(user_factory):
@@ -80,7 +82,7 @@ def test_listing_crud_lifecycle(api_client, owner, business, service):
     list_response = api_client.get(list_url)
     assert list_response.status_code == 200
     payload = list_response.json()
-    results = payload.get("results", payload)
+    results = extract_results(payload)
     assert any(item["id"] == listing_id for item in results)
 
     delete_response = api_client.delete(detail_url)

--- a/backend/api/tests/test_auth.py
+++ b/backend/api/tests/test_auth.py
@@ -1,4 +1,4 @@
-"""Authentication flow tests for the versioned API."""
+"""Authentication helper tests for the public API."""
 
 from __future__ import annotations
 
@@ -15,16 +15,18 @@ def extract_results(payload):
 
 
 @pytest.mark.django_db
-def test_jwt_auth_flow(api_client, user_factory):
-    password = "StrongPass123!"
-    user = user_factory(email="auth@example.com", password=password)
+def test_jwt_authentication_flow(api_client, user_factory):
+    """Exercise the token obtain/refresh endpoints exposed by the API."""
+
+    password = "Str0ngPass!"
+    user = user_factory(email="api-auth@example.com", password=password)
 
     token_url = reverse("api_auth:jwt-create")
     response = api_client.post(token_url, {"email": user.email, "password": password})
 
     assert response.status_code == 200
     tokens = response.json()
-    assert "access" in tokens and "refresh" in tokens
+    assert {"access", "refresh"} <= tokens.keys()
 
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {tokens['access']}")
     user_list_url = reverse("api:users-list")
@@ -38,4 +40,17 @@ def test_jwt_auth_flow(api_client, user_factory):
     refresh_response = api_client.post(refresh_url, {"refresh": tokens["refresh"]})
 
     assert refresh_response.status_code == 200
-    assert "access" in refresh_response.json()
+    refreshed = refresh_response.json()
+    assert "access" in refreshed and refreshed["access"]
+
+
+@pytest.mark.django_db
+def test_jwt_authentication_rejects_bad_credentials(api_client):
+    """Ensure invalid credentials do not yield tokens."""
+
+    token_url = reverse("api_auth:jwt-create")
+    response = api_client.post(token_url, {"email": "nobody@example.com", "password": "bad"})
+
+    assert response.status_code in {400, 401}
+    payload = response.json()
+    assert payload.get("detail") or payload.get("non_field_errors")

--- a/backend/api/tests/test_auth.py
+++ b/backend/api/tests/test_auth.py
@@ -2,23 +2,19 @@
 
 from __future__ import annotations
 
+import secrets
+
 import pytest
 from django.urls import reverse
 
-
-def extract_results(payload):
-    """Return the result list from paginated responses."""
-
-    if isinstance(payload, dict) and "results" in payload:
-        return payload["results"]
-    return payload
+from backend.tests.utils import extract_results
 
 
 @pytest.mark.django_db
 def test_jwt_authentication_flow(api_client, user_factory):
     """Exercise the token obtain/refresh endpoints exposed by the API."""
 
-    password = "Str0ngPass!"
+    password = secrets.token_urlsafe(16)
     user = user_factory(email="api-auth@example.com", password=password)
 
     token_url = reverse("api_auth:jwt-create")
@@ -26,7 +22,7 @@ def test_jwt_authentication_flow(api_client, user_factory):
 
     assert response.status_code == 200
     tokens = response.json()
-    assert {"access", "refresh"} <= tokens.keys()
+    assert "access" in tokens and "refresh" in tokens
 
     api_client.credentials(HTTP_AUTHORIZATION=f"Bearer {tokens['access']}")
     user_list_url = reverse("api:users-list")

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Backend test package."""

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,21 +2,17 @@
 
 from __future__ import annotations
 
+import secrets
+
 import pytest
 from django.urls import reverse
 
-
-def extract_results(payload):
-    """Return the result list from paginated responses."""
-
-    if isinstance(payload, dict) and "results" in payload:
-        return payload["results"]
-    return payload
+from backend.tests.utils import extract_results
 
 
 @pytest.mark.django_db
 def test_jwt_auth_flow(api_client, user_factory):
-    password = "StrongPass123!"
+    password = secrets.token_urlsafe(16)
     user = user_factory(email="auth@example.com", password=password)
 
     token_url = reverse("api_auth:jwt-create")

--- a/backend/tests/test_viewsets_and_models.py
+++ b/backend/tests/test_viewsets_and_models.py
@@ -9,11 +9,10 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
+from api.viewsets import NotificationViewSet, PaymentTransactionViewSet
 from business.models import BusinessProfile
 from notifications.adapters import NotificationResult
-from notifications.viewsets import NotificationViewSet
 from payments.adapters import MockPaymentGateway, PaymentResult, PaymentStatus
-from payments.viewsets import PaymentTransactionViewSet
 
 
 def extract_results(payload):

--- a/backend/tests/test_viewsets_and_models.py
+++ b/backend/tests/test_viewsets_and_models.py
@@ -14,13 +14,7 @@ from business.models import BusinessProfile
 from notifications.adapters import NotificationResult
 from payments.adapters import MockPaymentGateway, PaymentResult, PaymentStatus
 
-
-def extract_results(payload):
-    """Return the result list from paginated responses."""
-
-    if isinstance(payload, dict) and "results" in payload:
-        return payload["results"]
-    return payload
+from backend.tests.utils import extract_results
 
 
 @pytest.mark.django_db

--- a/backend/tests/utils.py
+++ b/backend/tests/utils.py
@@ -1,0 +1,19 @@
+"""Shared utilities for backend test suites."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def extract_results(payload: Any):
+    """Return the result list from paginated API responses.
+
+    The API returns paginated responses as dictionaries containing a
+    ``results`` key. Non-paginated responses return a list directly. This
+    helper normalises the shape across both cases for test assertions.
+    """
+
+    if isinstance(payload, Mapping) and "results" in payload:
+        return payload["results"]
+    return payload

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-environ>=0.11.2
 django-cors-headers>=4.3.1
 psycopg[binary]>=3.1.18
 djangorestframework>=3.15.1
-drf-spectacular>=0.27.2
+drf-spectacular==0.28.0
 djangorestframework-simplejwt>=5.4.0
 django-filter>=24.1
 channels>=4.1.0


### PR DESCRIPTION
## Summary
- scaffold the new `backend/api/tests` package with CRUD and authentication coverage against the Listing and JWT endpoints
- align existing backend tests with the refactored API viewset locations and action routes while keeping behavior checks intact
- regenerate the OpenAPI schema artifacts to reflect the current `/api/v1` endpoints

## Testing
- pytest -q backend/api/tests backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68ed8eb1b70c8320925f375ba116fda7