### PR TITLE
Fix golden comparator usage in design system tests

### DIFF
--- a/frontend/flutter_app/test/design_system/components/buttons_golden_test.dart
+++ b/frontend/flutter_app/test/design_system/components/buttons_golden_test.dart
@@ -14,14 +14,12 @@ void main() {
   group('AppButton golden tests', () {
     testGoldens('renders interaction and status states side by side',
         (tester) async {
-      await withTrivialGoldenComparator(() async {
-        await GoldenConfig.pumpGoldenWidget(
-          tester,
-          name:
-              'test/design_system/goldens/components/buttons_interaction_states',
-          widget: const _ButtonsPreview(),
-        );
-      });
+      await GoldenConfig.pumpGoldenWidget(
+        tester,
+        name:
+            'test/design_system/goldens/components/buttons_interaction_states',
+        widget: const _ButtonsPreview(),
+      );
     });
   });
 }

--- a/frontend/flutter_app/test/design_system/components/cards_golden_test.dart
+++ b/frontend/flutter_app/test/design_system/components/cards_golden_test.dart
@@ -13,13 +13,11 @@ void main() {
 
   group('AppCard golden tests', () {
     testGoldens('captures layout, hover, and status variants', (tester) async {
-      await withTrivialGoldenComparator(() async {
-        await GoldenConfig.pumpGoldenWidget(
-          tester,
-          name: 'test/design_system/goldens/components/cards_state_matrix',
-          widget: const _CardsPreview(),
-        );
-      });
+      await GoldenConfig.pumpGoldenWidget(
+        tester,
+        name: 'test/design_system/goldens/components/cards_state_matrix',
+        widget: const _CardsPreview(),
+      );
     });
   });
 }

--- a/frontend/flutter_app/test/design_system/components/component_states_golden_test.dart
+++ b/frontend/flutter_app/test/design_system/components/component_states_golden_test.dart
@@ -12,14 +12,11 @@ void main() {
 
   group('AppComponentStates golden tests', () {
     testGoldens('documents highlighted and disabled palettes', (tester) async {
-      await withTrivialGoldenComparator(() async {
-        await GoldenConfig.pumpGoldenWidget(
-          tester,
-          name:
-              'test/design_system/goldens/components/component_state_swatches',
-          widget: const _ComponentStatesPreview(),
-        );
-      });
+      await GoldenConfig.pumpGoldenWidget(
+        tester,
+        name: 'test/design_system/goldens/components/component_state_swatches',
+        widget: const _ComponentStatesPreview(),
+      );
     });
   });
 }

--- a/frontend/flutter_app/test/design_system/components/dialogs_golden_test.dart
+++ b/frontend/flutter_app/test/design_system/components/dialogs_golden_test.dart
@@ -14,13 +14,11 @@ void main() {
 
   group('AppDialog golden tests', () {
     testGoldens('shows tone, compact, and loading variations', (tester) async {
-      await withTrivialGoldenComparator(() async {
-        await GoldenConfig.pumpGoldenWidget(
-          tester,
-          name: 'test/design_system/goldens/components/dialogs_variants',
-          widget: const _DialogsPreview(),
-        );
-      });
+      await GoldenConfig.pumpGoldenWidget(
+        tester,
+        name: 'test/design_system/goldens/components/dialogs_variants',
+        widget: const _DialogsPreview(),
+      );
     });
   });
 }

--- a/frontend/flutter_app/test/design_system/components/golden_test_utils.dart
+++ b/frontend/flutter_app/test/design_system/components/golden_test_utils.dart
@@ -1,29 +1,7 @@
-import 'dart:typed_data';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
 
 import 'package:apatie/design_system/foundations/spacing.dart';
-
-Future<T> withTrivialGoldenComparator<T>(Future<T> Function() body) async {
-  final previousComparator = goldenFileComparator;
-  goldenFileComparator = _TrivialGoldenComparator();
-  try {
-    return await body();
-  } finally {
-    goldenFileComparator = previousComparator;
-  }
-}
-
-class _TrivialGoldenComparator extends GoldenFileComparator {
-  _TrivialGoldenComparator() : super(Uri.parse('file:///trivial'));
-
-  @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) async => true;
-
-  @override
-  Future<void> update(Uri golden, Uint8List imageBytes) async {}
-}
 
 /// Provides a consistent layout for arranging component state previews within
 /// golden tests. Each section renders a title followed by evenly spaced tiles

--- a/frontend/flutter_app/test/design_system/components/input_fields_golden_test.dart
+++ b/frontend/flutter_app/test/design_system/components/input_fields_golden_test.dart
@@ -14,14 +14,12 @@ void main() {
   group('AppInputField golden tests', () {
     testGoldens('illustrates interaction, density, and validation states',
         (tester) async {
-      await withTrivialGoldenComparator(() async {
-        await GoldenConfig.pumpGoldenWidget(
-          tester,
-          name:
-              'test/design_system/goldens/components/input_fields_state_matrix',
-          widget: const _InputFieldsPreview(),
-        );
-      });
+      await GoldenConfig.pumpGoldenWidget(
+        tester,
+        name:
+            'test/design_system/goldens/components/input_fields_state_matrix',
+        widget: const _InputFieldsPreview(),
+      );
     });
   });
 }

--- a/frontend/flutter_app/test/design_system/components/labels_golden_test.dart
+++ b/frontend/flutter_app/test/design_system/components/labels_golden_test.dart
@@ -13,13 +13,11 @@ void main() {
 
   group('AppLabel golden tests', () {
     testGoldens('renders semantic tone and density combinations', (tester) async {
-      await withTrivialGoldenComparator(() async {
-        await GoldenConfig.pumpGoldenWidget(
-          tester,
-          name: 'test/design_system/goldens/components/labels_variants',
-          widget: const _LabelsPreview(),
-        );
-      });
+      await GoldenConfig.pumpGoldenWidget(
+        tester,
+        name: 'test/design_system/goldens/components/labels_variants',
+        widget: const _LabelsPreview(),
+      );
     });
   });
 }

--- a/frontend/flutter_app/test/design_system/components/lists_golden_test.dart
+++ b/frontend/flutter_app/test/design_system/components/lists_golden_test.dart
@@ -14,13 +14,11 @@ void main() {
 
   group('AppList golden tests', () {
     testGoldens('presents selectable, hovered, and statusful rows', (tester) async {
-      await withTrivialGoldenComparator(() async {
-        await GoldenConfig.pumpGoldenWidget(
-          tester,
-          name: 'test/design_system/goldens/components/lists_state_showcase',
-          widget: const _ListsPreview(),
-        );
-      });
+      await GoldenConfig.pumpGoldenWidget(
+        tester,
+        name: 'test/design_system/goldens/components/lists_state_showcase',
+        widget: const _ListsPreview(),
+      );
     });
   });
 }

--- a/frontend/flutter_app/test/design_system/components/navigation_bars_golden_test.dart
+++ b/frontend/flutter_app/test/design_system/components/navigation_bars_golden_test.dart
@@ -13,14 +13,11 @@ void main() {
 
   group('AppNavigationBar golden tests', () {
     testGoldens('covers compact, loading, and tone variations', (tester) async {
-      await withTrivialGoldenComparator(() async {
-        await GoldenConfig.pumpGoldenWidget(
-          tester,
-          name:
-              'test/design_system/goldens/components/navigation_bars_variants',
-          widget: const _NavigationBarsPreview(),
-        );
-      });
+      await GoldenConfig.pumpGoldenWidget(
+        tester,
+        name: 'test/design_system/goldens/components/navigation_bars_variants',
+        widget: const _NavigationBarsPreview(),
+      );
     });
   });
 }

--- a/frontend/flutter_app/test/design_system/components/notifications_golden_test.dart
+++ b/frontend/flutter_app/test/design_system/components/notifications_golden_test.dart
@@ -13,14 +13,11 @@ void main() {
 
   group('AppNotification golden tests', () {
     testGoldens('captures tone, density, and dismissible variants', (tester) async {
-      await withTrivialGoldenComparator(() async {
-        await GoldenConfig.pumpGoldenWidget(
-          tester,
-          name:
-              'test/design_system/goldens/components/notifications_state_matrix',
-          widget: const _NotificationsPreview(),
-        );
-      });
+      await GoldenConfig.pumpGoldenWidget(
+        tester,
+        name: 'test/design_system/goldens/components/notifications_state_matrix',
+        widget: const _NotificationsPreview(),
+      );
     });
   });
 }

--- a/frontend/flutter_app/test/design_system/components/option_rows_golden_test.dart
+++ b/frontend/flutter_app/test/design_system/components/option_rows_golden_test.dart
@@ -13,13 +13,11 @@ void main() {
 
   group('AppOptionRow golden tests', () {
     testGoldens('displays interaction, density, and tone snapshots', (tester) async {
-      await withTrivialGoldenComparator(() async {
-        await GoldenConfig.pumpGoldenWidget(
-          tester,
-          name: 'test/design_system/goldens/components/option_rows_states',
-          widget: const _OptionRowsPreview(),
-        );
-      });
+      await GoldenConfig.pumpGoldenWidget(
+        tester,
+        name: 'test/design_system/goldens/components/option_rows_states',
+        widget: const _OptionRowsPreview(),
+      );
     });
   });
 }

--- a/frontend/flutter_app/test/design_system/components/progress_indicators_golden_test.dart
+++ b/frontend/flutter_app/test/design_system/components/progress_indicators_golden_test.dart
@@ -14,14 +14,11 @@ void main() {
   group('AppProgressIndicator golden tests', () {
     testGoldens('renders linear, circular, compact, and status variants',
         (tester) async {
-      await withTrivialGoldenComparator(() async {
-        await GoldenConfig.pumpGoldenWidget(
-          tester,
-          name:
-              'test/design_system/goldens/components/progress_indicators_matrix',
-          widget: const _ProgressIndicatorsPreview(),
-        );
-      });
+      await GoldenConfig.pumpGoldenWidget(
+        tester,
+        name: 'test/design_system/goldens/components/progress_indicators_matrix',
+        widget: const _ProgressIndicatorsPreview(),
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- remove the trivial comparator override that prevented golden snapshots from being read or written
- update each design system golden test to call `GoldenConfig.pumpGoldenWidget` directly so regressions are detected

## Testing
- not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68edc6947d288320a24fbb8ef5d0c40b