### PR TITLE
Add accessibility widget tests for module flows

### DIFF
--- a/frontend/flutter_app/test/modules/README.md
+++ b/frontend/flutter_app/test/modules/README.md
@@ -3,16 +3,19 @@
 This document summarizes the behavioral widget tests that exercise the major user journeys for the Apatie modules. Every scenario runs in both left-to-right (English) and right-to-left (Persian) locales, with reduced-motion preferences applied in the RTL configuration to validate accessibility fallbacks.
 
 ## Appointments
+
 - **Flow progression & loading:** `appointments_accessibility_test.dart` validates the stepper progress indicator across all three steps and asserts that motion-aware transitions honor reduced-motion settings.
 - **Keyboard focus & announcements:** The test captures accessibility announcements emitted when focus traverses from the search field through list options and action buttons, ensuring FocusTraversalGroup ordering works for keyboard users.
 - **Error recovery & summary:** Selecting services, experts, and slots replaces the placeholder error hints ("هنوز انتخاب نشده است") in the summary card, confirming that completion feedback renders without residual error banners.
 
 ## Services
+
 - **Floating window accessibility:** `services_accessibility_test.dart` inspects the draggable window animation duration under motion reduction and checks status labels while toggling between expanded and minimized states.
 - **Keyboard focus & notifications:** The test verifies focus announcements on compact buttons, the warning banner shown in minimized mode, and the SnackBar that confirms monitoring completion, including dismissal after its timeout.
 - **Loading indicators:** Both the primary monitoring card and the floating window progress bars are asserted to expose their expected completion percentages.
 
 ## Marketplace
+
 - **Horizontal card interactions:** `marketplace_accessibility_test.dart` covers keyboard focus over action buttons, option selection feedback, and progress indicators that adjust when a new package is highlighted.
 - **Dialog accessibility:** Opening the dialog card pattern validates reduced-motion fade timing, focus traversal inside the dialog actions, and the closing announcement when the confirmation action is activated.
 - **Localization surface:** Headline expectations ensure each locale renders localized guidance so assistive announcements pair with the correct visible copy.

--- a/frontend/flutter_app/test/modules/README.md
+++ b/frontend/flutter_app/test/modules/README.md
@@ -1,0 +1,20 @@
+# Module Interaction Test Coverage
+
+This document summarizes the behavioral widget tests that exercise the major user journeys for the Apatie modules. Every scenario runs in both left-to-right (English) and right-to-left (Persian) locales, with reduced-motion preferences applied in the RTL configuration to validate accessibility fallbacks.
+
+## Appointments
+- **Flow progression & loading:** `appointments_accessibility_test.dart` validates the stepper progress indicator across all three steps and asserts that motion-aware transitions honor reduced-motion settings.
+- **Keyboard focus & announcements:** The test captures accessibility announcements emitted when focus traverses from the search field through list options and action buttons, ensuring FocusTraversalGroup ordering works for keyboard users.
+- **Error recovery & summary:** Selecting services, experts, and slots replaces the placeholder error hints ("هنوز انتخاب نشده است") in the summary card, confirming that completion feedback renders without residual error banners.
+
+## Services
+- **Floating window accessibility:** `services_accessibility_test.dart` inspects the draggable window animation duration under motion reduction and checks status labels while toggling between expanded and minimized states.
+- **Keyboard focus & notifications:** The test verifies focus announcements on compact buttons, the warning banner shown in minimized mode, and the SnackBar that confirms monitoring completion, including dismissal after its timeout.
+- **Loading indicators:** Both the primary monitoring card and the floating window progress bars are asserted to expose their expected completion percentages.
+
+## Marketplace
+- **Horizontal card interactions:** `marketplace_accessibility_test.dart` covers keyboard focus over action buttons, option selection feedback, and progress indicators that adjust when a new package is highlighted.
+- **Dialog accessibility:** Opening the dialog card pattern validates reduced-motion fade timing, focus traversal inside the dialog actions, and the closing announcement when the confirmation action is activated.
+- **Localization surface:** Headline expectations ensure each locale renders localized guidance so assistive announcements pair with the correct visible copy.
+
+All tests run via `flutter test test/modules` and can be extended with additional scenarios per module as new behaviors are introduced.

--- a/frontend/flutter_app/test/modules/appointments/appointments_accessibility_test.dart
+++ b/frontend/flutter_app/test/modules/appointments/appointments_accessibility_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:apatie/design_system/components/app_card.dart';
+import 'package:apatie/design_system/components/app_progress_indicator.dart';
+import 'package:apatie/l10n/app_localizations.dart';
+import 'package:apatie/modules/appointments/ui/patterns/full_screen_flow/appointments_full_screen_flow.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const configs = <_TestConfig>[
+    _TestConfig(
+      description: 'LTR locale without motion reduction',
+      locale: Locale('en'),
+      reduceMotion: false,
+    ),
+    _TestConfig(
+      description: 'RTL locale with reduced motion',
+      locale: Locale('fa'),
+      reduceMotion: true,
+    ),
+  ];
+
+  for (final config in configs) {
+    testWidgets(
+      'Appointments full-screen flow handles focus, announcements, and loading states — '
+      '${config.description}',
+      (tester) async {
+        final announcements = <String>[];
+        final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+        final previousHandler = messenger.getMockMethodCallHandler(SystemChannels.accessibility);
+        messenger.setMockMethodCallHandler(SystemChannels.accessibility, (methodCall) async {
+          if (methodCall.method == 'announce') {
+            announcements.add(methodCall.arguments as String);
+          }
+          return null;
+        });
+        addTearDown(() {
+          messenger.setMockMethodCallHandler(SystemChannels.accessibility, previousHandler);
+        });
+
+        await tester.pumpWidget(
+          _buildTestApp(
+            locale: config.locale,
+            reduceMotion: config.reduceMotion,
+            child: const AppointmentsFullScreenFlow(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final animatedSwitcher = tester.widget<AnimatedSwitcher>(find.byType(AnimatedSwitcher));
+        expect(
+          animatedSwitcher.duration,
+          config.reduceMotion ? Duration.zero : const Duration(milliseconds: 180),
+        );
+
+        expect(find.text('رزرو مرحله‌به‌مرحلهٔ نوبت رسمی'), findsOneWidget);
+
+        final initialProgress =
+            tester.widget<AppProgressIndicator>(find.byType(AppProgressIndicator).first);
+        expect(initialProgress.value, moreOrLessEquals(1 / 3));
+
+        await tester.tap(find.byType(TextField).first);
+        await tester.pump();
+        expect(
+          announcements,
+          contains('تمرکز روی فیلد جست‌وجوی خدمات قرار گرفت.'),
+        );
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(
+          announcements,
+          contains('تمرکز صفحه‌کلید روی گزینهٔ مشاورهٔ تغذیهٔ تخصصی قرار گرفت.'),
+        );
+
+        await tester.tap(find.text('مشاورهٔ تغذیهٔ تخصصی'));
+        await tester.pump();
+        expect(
+          announcements,
+          contains('گزینهٔ مشاورهٔ تغذیهٔ تخصصی انتخاب شد.'),
+        );
+
+        await tester.tap(find.text('ادامه'));
+        await tester.pumpAndSettle();
+        expect(find.text('مرحلهٔ دوم: انتخاب متخصص معتمد'), findsOneWidget);
+
+        final secondStepProgress =
+            tester.widget<AppProgressIndicator>(find.byType(AppProgressIndicator).first);
+        expect(secondStepProgress.value, moreOrLessEquals(2 / 3));
+
+        await tester.tap(find.text('دکتر میلاد برومند – متخصص قلب'));
+        await tester.pump();
+        expect(
+          announcements,
+          contains('گزینهٔ دکتر میلاد برومند – متخصص قلب انتخاب شد.'),
+        );
+
+        await tester.tap(find.text('ادامه'));
+        await tester.pumpAndSettle();
+        expect(find.text('مرحلهٔ نهایی: تأیید زمان مراجعه'), findsOneWidget);
+
+        final finalProgress =
+            tester.widget<AppProgressIndicator>(find.byType(AppProgressIndicator).first);
+        expect(finalProgress.value, moreOrLessEquals(1));
+
+        await tester.tap(find.text('سه‌شنبه ۲۵ مرداد، ساعت ۱۰:۳۰'));
+        await tester.pump();
+        expect(
+          announcements,
+          contains('گزینهٔ سه‌شنبه ۲۵ مرداد، ساعت ۱۰:۳۰ انتخاب شد.'),
+        );
+
+        final summaryCard = find.ancestor(
+          of: find.text('خلاصهٔ درخواست'),
+          matching: find.byType(AppCard),
+        );
+
+        expect(
+          find.descendant(
+            of: summaryCard,
+            matching: find.text('مشاورهٔ تغذیهٔ تخصصی'),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: summaryCard,
+            matching: find.text('دکتر میلاد برومند – متخصص قلب'),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: summaryCard,
+            matching: find.text('سه‌شنبه ۲۵ مرداد، ساعت ۱۰:۳۰'),
+          ),
+          findsOneWidget,
+        );
+        expect(find.textContaining('هنوز انتخاب نشده است'), findsNothing);
+        expect(find.text('ثبت نهایی نوبت'), findsOneWidget);
+      },
+    );
+  }
+}
+
+class _TestConfig {
+  const _TestConfig({
+    required this.description,
+    required this.locale,
+    required this.reduceMotion,
+  });
+
+  final String description;
+  final Locale locale;
+  final bool reduceMotion;
+}
+
+Widget _buildTestApp({
+  required Locale locale,
+  required bool reduceMotion,
+  required Widget child,
+}) {
+  return MaterialApp(
+    debugShowCheckedModeBanner: false,
+    locale: locale,
+    supportedLocales: AppLocalizations.supportedLocales,
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    home: Builder(
+      builder: (context) {
+        final mediaQuery = MediaQuery.of(context);
+        final override = mediaQuery.copyWith(
+          disableAnimations: reduceMotion,
+          accessibleNavigation: reduceMotion,
+        );
+        return MediaQuery(
+          data: override,
+          child: Scaffold(
+            body: child,
+          ),
+        );
+      },
+    ),
+  );
+}

--- a/frontend/flutter_app/test/modules/appointments/appointments_accessibility_test.dart
+++ b/frontend/flutter_app/test/modules/appointments/appointments_accessibility_test.dart
@@ -41,6 +41,8 @@ void main() {
           messenger.setMockMethodCallHandler(SystemChannels.accessibility, previousHandler);
         });
 
+        final strings = _AppointmentsStrings.forLocale(config.locale);
+
         await tester.pumpWidget(
           _buildTestApp(
             locale: config.locale,
@@ -56,7 +58,7 @@ void main() {
           config.reduceMotion ? Duration.zero : const Duration(milliseconds: 180),
         );
 
-        expect(find.text('رزرو مرحله‌به‌مرحلهٔ نوبت رسمی'), findsOneWidget);
+        expect(find.text(strings.flowTitle), findsOneWidget);
 
         final initialProgress =
             tester.widget<AppProgressIndicator>(find.byType(AppProgressIndicator).first);
@@ -66,83 +68,171 @@ void main() {
         await tester.pump();
         expect(
           announcements,
-          contains('تمرکز روی فیلد جست‌وجوی خدمات قرار گرفت.'),
+          contains(strings.serviceFieldFocusedAnnouncement),
         );
 
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
         await tester.pump();
         expect(
           announcements,
-          contains('تمرکز صفحه‌کلید روی گزینهٔ مشاورهٔ تغذیهٔ تخصصی قرار گرفت.'),
+          contains(strings.firstServiceFocusedAnnouncement),
         );
 
-        await tester.tap(find.text('مشاورهٔ تغذیهٔ تخصصی'));
+        await tester.tap(find.text(strings.nutritionConsultationService));
         await tester.pump();
         expect(
           announcements,
-          contains('گزینهٔ مشاورهٔ تغذیهٔ تخصصی انتخاب شد.'),
+          contains(strings.nutritionConsultationSelectedAnnouncement),
         );
 
-        await tester.tap(find.text('ادامه'));
+        await tester.tap(find.text(strings.continueLabel));
         await tester.pumpAndSettle();
-        expect(find.text('مرحلهٔ دوم: انتخاب متخصص معتمد'), findsOneWidget);
+        expect(find.text(strings.secondStepTitle), findsOneWidget);
 
         final secondStepProgress =
             tester.widget<AppProgressIndicator>(find.byType(AppProgressIndicator).first);
         expect(secondStepProgress.value, moreOrLessEquals(2 / 3));
 
-        await tester.tap(find.text('دکتر میلاد برومند – متخصص قلب'));
+        await tester.tap(find.text(strings.cardiologistExpert));
         await tester.pump();
         expect(
           announcements,
-          contains('گزینهٔ دکتر میلاد برومند – متخصص قلب انتخاب شد.'),
+          contains(strings.cardiologistSelectedAnnouncement),
         );
 
-        await tester.tap(find.text('ادامه'));
+        await tester.tap(find.text(strings.continueLabel));
         await tester.pumpAndSettle();
-        expect(find.text('مرحلهٔ نهایی: تأیید زمان مراجعه'), findsOneWidget);
+        expect(find.text(strings.finalStepTitle), findsOneWidget);
 
         final finalProgress =
             tester.widget<AppProgressIndicator>(find.byType(AppProgressIndicator).first);
         expect(finalProgress.value, moreOrLessEquals(1));
 
-        await tester.tap(find.text('سه‌شنبه ۲۵ مرداد، ساعت ۱۰:۳۰'));
+        await tester.tap(find.text(strings.firstTimeSlot));
         await tester.pump();
         expect(
           announcements,
-          contains('گزینهٔ سه‌شنبه ۲۵ مرداد، ساعت ۱۰:۳۰ انتخاب شد.'),
+          contains(strings.firstTimeSlotSelectedAnnouncement),
         );
 
         final summaryCard = find.ancestor(
-          of: find.text('خلاصهٔ درخواست'),
+          of: find.text(strings.summaryTitle),
           matching: find.byType(AppCard),
         );
 
         expect(
           find.descendant(
             of: summaryCard,
-            matching: find.text('مشاورهٔ تغذیهٔ تخصصی'),
+            matching: find.text(strings.nutritionConsultationService),
           ),
           findsOneWidget,
         );
         expect(
           find.descendant(
             of: summaryCard,
-            matching: find.text('دکتر میلاد برومند – متخصص قلب'),
+            matching: find.text(strings.cardiologistExpert),
           ),
           findsOneWidget,
         );
         expect(
           find.descendant(
             of: summaryCard,
-            matching: find.text('سه‌شنبه ۲۵ مرداد، ساعت ۱۰:۳۰'),
+            matching: find.text(strings.firstTimeSlot),
           ),
           findsOneWidget,
         );
-        expect(find.textContaining('هنوز انتخاب نشده است'), findsNothing);
-        expect(find.text('ثبت نهایی نوبت'), findsOneWidget);
+        expect(find.textContaining(strings.notSelectedLabel), findsNothing);
+        expect(find.text(strings.finalizeLabel), findsOneWidget);
       },
     );
+  }
+}
+
+class _AppointmentsStrings {
+  const _AppointmentsStrings({
+    required this.flowTitle,
+    required this.serviceFieldFocusedAnnouncement,
+    required this.firstServiceFocusedAnnouncement,
+    required this.nutritionConsultationService,
+    required this.nutritionConsultationSelectedAnnouncement,
+    required this.continueLabel,
+    required this.secondStepTitle,
+    required this.cardiologistExpert,
+    required this.cardiologistSelectedAnnouncement,
+    required this.finalStepTitle,
+    required this.firstTimeSlot,
+    required this.firstTimeSlotSelectedAnnouncement,
+    required this.summaryTitle,
+    required this.notSelectedLabel,
+    required this.finalizeLabel,
+  });
+
+  final String flowTitle;
+  final String serviceFieldFocusedAnnouncement;
+  final String firstServiceFocusedAnnouncement;
+  final String nutritionConsultationService;
+  final String nutritionConsultationSelectedAnnouncement;
+  final String continueLabel;
+  final String secondStepTitle;
+  final String cardiologistExpert;
+  final String cardiologistSelectedAnnouncement;
+  final String finalStepTitle;
+  final String firstTimeSlot;
+  final String firstTimeSlotSelectedAnnouncement;
+  final String summaryTitle;
+  final String notSelectedLabel;
+  final String finalizeLabel;
+
+  static _AppointmentsStrings forLocale(Locale locale) {
+    switch (locale.languageCode) {
+      case 'en':
+        return const _AppointmentsStrings(
+          flowTitle: 'رزرو مرحله‌به‌مرحلهٔ نوبت رسمی',
+          serviceFieldFocusedAnnouncement:
+              'تمرکز روی فیلد جست‌وجوی خدمات قرار گرفت.',
+          firstServiceFocusedAnnouncement:
+              'تمرکز صفحه‌کلید روی گزینهٔ مشاورهٔ تغذیهٔ تخصصی قرار گرفت.',
+          nutritionConsultationService: 'مشاورهٔ تغذیهٔ تخصصی',
+          nutritionConsultationSelectedAnnouncement:
+              'گزینهٔ مشاورهٔ تغذیهٔ تخصصی انتخاب شد.',
+          continueLabel: 'ادامه',
+          secondStepTitle: 'مرحلهٔ دوم: انتخاب متخصص معتمد',
+          cardiologistExpert: 'دکتر میلاد برومند – متخصص قلب',
+          cardiologistSelectedAnnouncement:
+              'گزینهٔ دکتر میلاد برومند – متخصص قلب انتخاب شد.',
+          finalStepTitle: 'مرحلهٔ نهایی: تأیید زمان مراجعه',
+          firstTimeSlot: 'سه‌شنبه ۲۵ مرداد، ساعت ۱۰:۳۰',
+          firstTimeSlotSelectedAnnouncement:
+              'گزینهٔ سه‌شنبه ۲۵ مرداد، ساعت ۱۰:۳۰ انتخاب شد.',
+          summaryTitle: 'خلاصهٔ درخواست',
+          notSelectedLabel: 'هنوز انتخاب نشده است',
+          finalizeLabel: 'ثبت نهایی نوبت',
+        );
+      case 'fa':
+      default:
+        return const _AppointmentsStrings(
+          flowTitle: 'رزرو مرحله‌به‌مرحلهٔ نوبت رسمی',
+          serviceFieldFocusedAnnouncement:
+              'تمرکز روی فیلد جست‌وجوی خدمات قرار گرفت.',
+          firstServiceFocusedAnnouncement:
+              'تمرکز صفحه‌کلید روی گزینهٔ مشاورهٔ تغذیهٔ تخصصی قرار گرفت.',
+          nutritionConsultationService: 'مشاورهٔ تغذیهٔ تخصصی',
+          nutritionConsultationSelectedAnnouncement:
+              'گزینهٔ مشاورهٔ تغذیهٔ تخصصی انتخاب شد.',
+          continueLabel: 'ادامه',
+          secondStepTitle: 'مرحلهٔ دوم: انتخاب متخصص معتمد',
+          cardiologistExpert: 'دکتر میلاد برومند – متخصص قلب',
+          cardiologistSelectedAnnouncement:
+              'گزینهٔ دکتر میلاد برومند – متخصص قلب انتخاب شد.',
+          finalStepTitle: 'مرحلهٔ نهایی: تأیید زمان مراجعه',
+          firstTimeSlot: 'سه‌شنبه ۲۵ مرداد، ساعت ۱۰:۳۰',
+          firstTimeSlotSelectedAnnouncement:
+              'گزینهٔ سه‌شنبه ۲۵ مرداد، ساعت ۱۰:۳۰ انتخاب شد.',
+          summaryTitle: 'خلاصهٔ درخواست',
+          notSelectedLabel: 'هنوز انتخاب نشده است',
+          finalizeLabel: 'ثبت نهایی نوبت',
+        );
+    }
   }
 }
 

--- a/frontend/flutter_app/test/modules/marketplace/marketplace_accessibility_test.dart
+++ b/frontend/flutter_app/test/modules/marketplace/marketplace_accessibility_test.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:apatie/design_system/components/app_card.dart';
+import 'package:apatie/design_system/components/app_progress_indicator.dart';
+import 'package:apatie/l10n/app_localizations.dart';
+import 'package:apatie/modules/marketplace/ui/patterns/dialog_card/marketplace_dialog_card_pattern.dart';
+import 'package:apatie/modules/marketplace/ui/patterns/horizontal_card_bar/marketplace_horizontal_card_bar.dart';
+import 'package:apatie/modules/marketplace/ui/screens/marketplace_page.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const configs = <_TestConfig>[
+    _TestConfig(
+      description: 'LTR locale without motion reduction',
+      locale: Locale('en'),
+      reduceMotion: false,
+    ),
+    _TestConfig(
+      description: 'RTL locale with reduced motion',
+      locale: Locale('fa'),
+      reduceMotion: true,
+    ),
+  ];
+
+  for (final config in configs) {
+    testWidgets(
+      'Marketplace patterns keep focus order, announcements, and loading cues aligned — '
+      '${config.description}',
+      (tester) async {
+        final announcements = <String>[];
+        final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+        final previousHandler = messenger.getMockMethodCallHandler(SystemChannels.accessibility);
+        messenger.setMockMethodCallHandler(SystemChannels.accessibility, (methodCall) async {
+          if (methodCall.method == 'announce') {
+            announcements.add(methodCall.arguments as String);
+          }
+          return null;
+        });
+        addTearDown(() {
+          messenger.setMockMethodCallHandler(SystemChannels.accessibility, previousHandler);
+        });
+
+        await tester.pumpWidget(
+          _buildTestApp(
+            locale: config.locale,
+            reduceMotion: config.reduceMotion,
+            child: const MarketplacePage(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        if (config.locale.languageCode == 'fa') {
+          expect(find.text('محصولات موجود را مرور کنید'), findsOneWidget);
+        } else {
+          expect(find.text('Browse available products'), findsOneWidget);
+        }
+
+        final horizontalBar = find.byType(MarketplaceHorizontalCardBar);
+        expect(horizontalBar, findsOneWidget);
+        final dialogPattern = find.byType(MarketplaceDialogCardPattern);
+        expect(dialogPattern, findsOneWidget);
+
+        await tester.tap(find.byType(TextField).first);
+        await tester.pump();
+        expect(
+          announcements,
+          contains('تمرکز روی فیلد عبارت جست‌وجو قرار گرفت.'),
+        );
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(
+          announcements.any(
+            (message) => message.contains('دکمهٔ افزودن به بررسی'),
+          ),
+          isTrue,
+        );
+
+        await tester.ensureVisible(find.text('برنامهٔ تغذیهٔ شخصی'));
+        await tester.pump();
+        await tester.tap(find.text('انتخاب فوری').at(1));
+        await tester.pumpAndSettle();
+        expect(
+          announcements,
+          contains('دکمهٔ انتخاب فوری فشرده شد.'),
+        );
+
+        final selectedCard = find.ancestor(
+          of: find.text('برنامهٔ تغذیهٔ شخصی'),
+          matching: find.byType(AppCard),
+        );
+        expect(
+          find.descendant(
+            of: selectedCard,
+            matching: find.text('پس از انتخاب می‌توانید سفارش را نهایی کنید.'),
+          ),
+          findsOneWidget,
+        );
+
+        final firstCard = find.ancestor(
+          of: find.text('پکیج غربالگری قلب و عروق'),
+          matching: find.byType(AppCard),
+        );
+        expect(
+          find.descendant(
+            of: firstCard,
+            matching: find.text('برای مقایسهٔ دقیق گزینه‌ها را مرور کنید.'),
+          ),
+          findsOneWidget,
+        );
+
+        final progressValues = tester
+            .widgetList<AppProgressIndicator>(find.descendant(
+          of: horizontalBar,
+          matching: find.byType(AppProgressIndicator),
+        ))
+            .map((indicator) => indicator.value)
+            .whereType<double>()
+            .toList();
+        expect(progressValues.any((value) => (value - 0.9).abs() < 0.01), isTrue);
+        expect(progressValues.where((value) => (value - 0.6).abs() < 0.01).length, greaterThanOrEqualTo(1));
+
+        await tester.tap(find.text('مشاهدهٔ کارت در گفت‌وگو'));
+        await tester.pumpAndSettle();
+        expect(find.text('جزئیات رسمی خدمت انتخاب‌شده'), findsOneWidget);
+
+        final dialogOpacity = tester.widget<AnimatedOpacity>(
+          find.descendant(
+            of: find.bySemanticsLabel('گفت‌وگوی رسمی برای بررسی کارت خدمت'),
+            matching: find.byType(AnimatedOpacity),
+          ),
+        );
+        expect(
+          dialogOpacity.duration,
+          config.reduceMotion ? Duration.zero : const Duration(milliseconds: 160),
+        );
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(
+          announcements.any((message) => message.contains('دکمهٔ افزودن به مقایسه')),
+          isTrue,
+        );
+
+        await tester.tap(find.text('تأیید انتخاب'));
+        await tester.pumpAndSettle();
+        expect(
+          announcements,
+          contains('دکمهٔ تأیید انتخاب فشرده شد.'),
+        );
+        expect(find.text('جزئیات رسمی خدمت انتخاب‌شده'), findsNothing);
+      },
+    );
+  }
+}
+
+class _TestConfig {
+  const _TestConfig({
+    required this.description,
+    required this.locale,
+    required this.reduceMotion,
+  });
+
+  final String description;
+  final Locale locale;
+  final bool reduceMotion;
+}
+
+Widget _buildTestApp({
+  required Locale locale,
+  required bool reduceMotion,
+  required Widget child,
+}) {
+  return MaterialApp(
+    debugShowCheckedModeBanner: false,
+    locale: locale,
+    supportedLocales: AppLocalizations.supportedLocales,
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    home: Builder(
+      builder: (context) {
+        final mediaQuery = MediaQuery.of(context);
+        final override = mediaQuery.copyWith(
+          disableAnimations: reduceMotion,
+          accessibleNavigation: reduceMotion,
+        );
+        return MediaQuery(
+          data: override,
+          child: Scaffold(
+            body: child,
+          ),
+        );
+      },
+    ),
+  );
+}

--- a/frontend/flutter_app/test/modules/marketplace/marketplace_accessibility_test.dart
+++ b/frontend/flutter_app/test/modules/marketplace/marketplace_accessibility_test.dart
@@ -43,6 +43,8 @@ void main() {
           messenger.setMockMethodCallHandler(SystemChannels.accessibility, previousHandler);
         });
 
+        final strings = _MarketplaceStrings.forLocale(config.locale);
+
         await tester.pumpWidget(
           _buildTestApp(
             locale: config.locale,
@@ -52,11 +54,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        if (config.locale.languageCode == 'fa') {
-          expect(find.text('محصولات موجود را مرور کنید'), findsOneWidget);
-        } else {
-          expect(find.text('Browse available products'), findsOneWidget);
-        }
+        expect(find.text(strings.marketplaceHeadline), findsOneWidget);
 
         final horizontalBar = find.byType(MarketplaceHorizontalCardBar);
         expect(horizontalBar, findsOneWidget);
@@ -67,47 +65,47 @@ void main() {
         await tester.pump();
         expect(
           announcements,
-          contains('تمرکز روی فیلد عبارت جست‌وجو قرار گرفت.'),
+          contains(strings.searchFieldFocusedAnnouncement),
         );
 
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
         await tester.pump();
         expect(
           announcements.any(
-            (message) => message.contains('دکمهٔ افزودن به بررسی'),
+            (message) => message.contains(strings.addToReviewButtonLabel),
           ),
           isTrue,
         );
 
-        await tester.ensureVisible(find.text('برنامهٔ تغذیهٔ شخصی'));
+        await tester.ensureVisible(find.text(strings.personalNutritionProgramTitle));
         await tester.pump();
-        await tester.tap(find.text('انتخاب فوری').at(1));
+        await tester.tap(find.text(strings.quickSelectButtonLabel).at(1));
         await tester.pumpAndSettle();
         expect(
           announcements,
-          contains('دکمهٔ انتخاب فوری فشرده شد.'),
+          contains(strings.quickSelectPressedAnnouncement),
         );
 
         final selectedCard = find.ancestor(
-          of: find.text('برنامهٔ تغذیهٔ شخصی'),
+          of: find.text(strings.personalNutritionProgramTitle),
           matching: find.byType(AppCard),
         );
         expect(
           find.descendant(
             of: selectedCard,
-            matching: find.text('پس از انتخاب می‌توانید سفارش را نهایی کنید.'),
+            matching: find.text(strings.quickSelectSupportingText),
           ),
           findsOneWidget,
         );
 
         final firstCard = find.ancestor(
-          of: find.text('پکیج غربالگری قلب و عروق'),
+          of: find.text(strings.cardiacScreeningPackageTitle),
           matching: find.byType(AppCard),
         );
         expect(
           find.descendant(
             of: firstCard,
-            matching: find.text('برای مقایسهٔ دقیق گزینه‌ها را مرور کنید.'),
+            matching: find.text(strings.reviewPromptText),
           ),
           findsOneWidget,
         );
@@ -123,13 +121,13 @@ void main() {
         expect(progressValues.any((value) => (value - 0.9).abs() < 0.01), isTrue);
         expect(progressValues.where((value) => (value - 0.6).abs() < 0.01).length, greaterThanOrEqualTo(1));
 
-        await tester.tap(find.text('مشاهدهٔ کارت در گفت‌وگو'));
+        await tester.tap(find.text(strings.openDialogButtonLabel));
         await tester.pumpAndSettle();
-        expect(find.text('جزئیات رسمی خدمت انتخاب‌شده'), findsOneWidget);
+        expect(find.text(strings.dialogTitle), findsOneWidget);
 
         final dialogOpacity = tester.widget<AnimatedOpacity>(
           find.descendant(
-            of: find.bySemanticsLabel('گفت‌وگوی رسمی برای بررسی کارت خدمت'),
+            of: find.bySemanticsLabel(strings.dialogSemanticsLabel),
             matching: find.byType(AnimatedOpacity),
           ),
         );
@@ -141,19 +139,106 @@ void main() {
         await tester.sendKeyEvent(LogicalKeyboardKey.tab);
         await tester.pump();
         expect(
-          announcements.any((message) => message.contains('دکمهٔ افزودن به مقایسه')),
+          announcements
+              .any((message) => message.contains(strings.addToComparisonButtonLabel)),
           isTrue,
         );
 
-        await tester.tap(find.text('تأیید انتخاب'));
+        await tester.tap(find.text(strings.confirmSelectionButtonLabel));
         await tester.pumpAndSettle();
         expect(
           announcements,
-          contains('دکمهٔ تأیید انتخاب فشرده شد.'),
+          contains(strings.confirmSelectionPressedAnnouncement),
         );
-        expect(find.text('جزئیات رسمی خدمت انتخاب‌شده'), findsNothing);
+        expect(find.text(strings.dialogTitle), findsNothing);
       },
     );
+  }
+}
+
+class _MarketplaceStrings {
+  const _MarketplaceStrings({
+    required this.marketplaceHeadline,
+    required this.searchFieldFocusedAnnouncement,
+    required this.addToReviewButtonLabel,
+    required this.personalNutritionProgramTitle,
+    required this.quickSelectButtonLabel,
+    required this.quickSelectPressedAnnouncement,
+    required this.quickSelectSupportingText,
+    required this.cardiacScreeningPackageTitle,
+    required this.reviewPromptText,
+    required this.openDialogButtonLabel,
+    required this.dialogTitle,
+    required this.dialogSemanticsLabel,
+    required this.addToComparisonButtonLabel,
+    required this.confirmSelectionButtonLabel,
+    required this.confirmSelectionPressedAnnouncement,
+  });
+
+  final String marketplaceHeadline;
+  final String searchFieldFocusedAnnouncement;
+  final String addToReviewButtonLabel;
+  final String personalNutritionProgramTitle;
+  final String quickSelectButtonLabel;
+  final String quickSelectPressedAnnouncement;
+  final String quickSelectSupportingText;
+  final String cardiacScreeningPackageTitle;
+  final String reviewPromptText;
+  final String openDialogButtonLabel;
+  final String dialogTitle;
+  final String dialogSemanticsLabel;
+  final String addToComparisonButtonLabel;
+  final String confirmSelectionButtonLabel;
+  final String confirmSelectionPressedAnnouncement;
+
+  static _MarketplaceStrings forLocale(Locale locale) {
+    switch (locale.languageCode) {
+      case 'en':
+        return const _MarketplaceStrings(
+          marketplaceHeadline: 'Browse available products',
+          searchFieldFocusedAnnouncement:
+              'تمرکز روی فیلد عبارت جست‌وجو قرار گرفت.',
+          addToReviewButtonLabel: 'دکمهٔ افزودن به بررسی',
+          personalNutritionProgramTitle: 'برنامهٔ تغذیهٔ شخصی',
+          quickSelectButtonLabel: 'انتخاب فوری',
+          quickSelectPressedAnnouncement:
+              'دکمهٔ انتخاب فوری فشرده شد.',
+          quickSelectSupportingText:
+              'پس از انتخاب می‌توانید سفارش را نهایی کنید.',
+          cardiacScreeningPackageTitle: 'پکیج غربالگری قلب و عروق',
+          reviewPromptText: 'برای مقایسهٔ دقیق گزینه‌ها را مرور کنید.',
+          openDialogButtonLabel: 'مشاهدهٔ کارت در گفت‌وگو',
+          dialogTitle: 'جزئیات رسمی خدمت انتخاب‌شده',
+          dialogSemanticsLabel: 'گفت‌وگوی رسمی برای بررسی کارت خدمت',
+          addToComparisonButtonLabel: 'دکمهٔ افزودن به مقایسه',
+          confirmSelectionButtonLabel: 'تأیید انتخاب',
+          confirmSelectionPressedAnnouncement:
+              'دکمهٔ تأیید انتخاب فشرده شد.',
+        );
+      case 'fa':
+      default:
+        return const _MarketplaceStrings(
+          marketplaceHeadline: 'محصولات موجود را مرور کنید',
+          searchFieldFocusedAnnouncement:
+              'تمرکز روی فیلد عبارت جست‌وجو قرار گرفت.',
+          addToReviewButtonLabel: 'دکمهٔ افزودن به بررسی',
+          personalNutritionProgramTitle: 'برنامهٔ تغذیهٔ شخصی',
+          quickSelectButtonLabel: 'انتخاب فوری',
+          quickSelectPressedAnnouncement:
+              'دکمهٔ انتخاب فوری فشرده شد.',
+          quickSelectSupportingText:
+              'پس از انتخاب می‌توانید سفارش را نهایی کنید.',
+          cardiacScreeningPackageTitle: 'پکیج غربالگری قلب و عروق',
+          reviewPromptText: 'برای مقایسهٔ دقیق گزینه‌ها را مرور کنید.',
+          openDialogButtonLabel: 'مشاهدهٔ کارت در گفت‌وگو',
+          dialogTitle: 'جزئیات رسمی خدمت انتخاب‌شده',
+          dialogSemanticsLabel: 'گفت‌وگوی رسمی برای بررسی کارت خدمت',
+          addToComparisonButtonLabel: 'دکمهٔ افزودن به مقایسه',
+          confirmSelectionButtonLabel: 'تأیید انتخاب',
+          confirmSelectionPressedAnnouncement:
+              'دکمهٔ تأیید انتخاب فشرده شد.',
+        );
+    }
   }
 }
 

--- a/frontend/flutter_app/test/modules/services/services_accessibility_test.dart
+++ b/frontend/flutter_app/test/modules/services/services_accessibility_test.dart
@@ -40,6 +40,8 @@ void main() {
           messenger.setMockMethodCallHandler(SystemChannels.accessibility, previousHandler);
         });
 
+        final strings = _ServicesStrings.forLocale(config.locale);
+
         await tester.pumpWidget(
           _buildTestApp(
             locale: config.locale,
@@ -51,7 +53,7 @@ void main() {
 
         final floatingContainer = tester.widget<AnimatedContainer>(
           find.descendant(
-            of: find.bySemanticsLabel('پنجرهٔ شناور برای پایش زنده'),
+            of: find.bySemanticsLabel(strings.floatingWindowSemanticsLabel),
             matching: find.byType(AnimatedContainer),
           ),
         );
@@ -80,42 +82,108 @@ void main() {
         await tester.pump();
         expect(
           announcements.any(
-            (message) => message.contains('دکمهٔ کوچک‌سازی'),
+            (message) => message.contains(strings.minimizeButtonLabel),
           ),
           isTrue,
         );
 
-        await tester.tap(find.text('کوچک‌سازی'));
+        await tester.tap(find.text(strings.minimizeLabel));
         await tester.pumpAndSettle();
         expect(
           announcements,
-          contains('دکمهٔ کوچک‌سازی فشرده شد.'),
+          contains(strings.minimizePressedAnnouncement),
         );
-        expect(find.text('حالت فشرده'), findsOneWidget);
-        expect(find.textContaining('پنجره در حالت فشرده'), findsOneWidget);
+        expect(find.text(strings.compactStateLabel), findsOneWidget);
+        expect(find.textContaining(strings.compactStateDescription), findsOneWidget);
 
-        await tester.tap(find.text('پایان پایش'));
+        await tester.tap(find.text(strings.finishMonitoringLabel));
         await tester.pump();
         expect(
           announcements,
-          contains('دکمهٔ پایان پایش فشرده شد.'),
+          contains(strings.finishMonitoringPressedAnnouncement),
         );
         await tester.pump();
-        expect(find.text('پایش زنده با موفقیت پایان یافت.'), findsOneWidget);
+        expect(find.text(strings.monitoringFinishedMessage), findsOneWidget);
 
         await tester.pump(const Duration(seconds: 4));
         await tester.pumpAndSettle();
-        expect(find.text('پایش زنده با موفقیت پایان یافت.'), findsNothing);
+        expect(find.text(strings.monitoringFinishedMessage), findsNothing);
 
-        await tester.tap(find.text('بازگشایی پنجره'));
+        await tester.tap(find.text(strings.restoreLabel));
         await tester.pumpAndSettle();
         expect(
           announcements,
-          contains('دکمهٔ بازگشایی پنجره فشرده شد.'),
+          contains(strings.restorePressedAnnouncement),
         );
-        expect(find.text('فعال'), findsOneWidget);
+        expect(find.text(strings.activeLabel), findsOneWidget);
       },
     );
+  }
+}
+
+class _ServicesStrings {
+  const _ServicesStrings({
+    required this.floatingWindowSemanticsLabel,
+    required this.minimizeButtonLabel,
+    required this.minimizeLabel,
+    required this.minimizePressedAnnouncement,
+    required this.compactStateLabel,
+    required this.compactStateDescription,
+    required this.finishMonitoringLabel,
+    required this.finishMonitoringPressedAnnouncement,
+    required this.monitoringFinishedMessage,
+    required this.restoreLabel,
+    required this.restorePressedAnnouncement,
+    required this.activeLabel,
+  });
+
+  final String floatingWindowSemanticsLabel;
+  final String minimizeButtonLabel;
+  final String minimizeLabel;
+  final String minimizePressedAnnouncement;
+  final String compactStateLabel;
+  final String compactStateDescription;
+  final String finishMonitoringLabel;
+  final String finishMonitoringPressedAnnouncement;
+  final String monitoringFinishedMessage;
+  final String restoreLabel;
+  final String restorePressedAnnouncement;
+  final String activeLabel;
+
+  static _ServicesStrings forLocale(Locale locale) {
+    switch (locale.languageCode) {
+      case 'en':
+        return const _ServicesStrings(
+          floatingWindowSemanticsLabel: 'پنجرهٔ شناور برای پایش زنده',
+          minimizeButtonLabel: 'دکمهٔ کوچک‌سازی',
+          minimizeLabel: 'کوچک‌سازی',
+          minimizePressedAnnouncement: 'دکمهٔ کوچک‌سازی فشرده شد.',
+          compactStateLabel: 'حالت فشرده',
+          compactStateDescription: 'پنجره در حالت فشرده قرار دارد.',
+          finishMonitoringLabel: 'پایان پایش',
+          finishMonitoringPressedAnnouncement: 'دکمهٔ پایان پایش فشرده شد.',
+          monitoringFinishedMessage: 'پایش زنده با موفقیت پایان یافت.',
+          restoreLabel: 'بازگشایی پنجره',
+          restorePressedAnnouncement: 'دکمهٔ بازگشایی پنجره فشرده شد.',
+          activeLabel: 'فعال',
+        );
+      case 'fa':
+      default:
+        return const _ServicesStrings(
+          floatingWindowSemanticsLabel: 'پنجرهٔ شناور برای پایش زنده',
+          minimizeButtonLabel: 'دکمهٔ کوچک‌سازی',
+          minimizeLabel: 'کوچک‌سازی',
+          minimizePressedAnnouncement: 'دکمهٔ کوچک‌سازی فشرده شد.',
+          compactStateLabel: 'حالت فشرده',
+          compactStateDescription: 'پنجره در حالت فشرده قرار دارد.',
+          finishMonitoringLabel: 'پایان پایش',
+          finishMonitoringPressedAnnouncement: 'دکمهٔ پایان پایش فشرده شد.',
+          monitoringFinishedMessage: 'پایش زنده با موفقیت پایان یافت.',
+          restoreLabel: 'بازگشایی پنجره',
+          restorePressedAnnouncement: 'دکمهٔ بازگشایی پنجره فشرده شد.',
+          activeLabel: 'فعال',
+        );
+    }
   }
 }
 

--- a/frontend/flutter_app/test/modules/services/services_accessibility_test.dart
+++ b/frontend/flutter_app/test/modules/services/services_accessibility_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:apatie/design_system/components/app_progress_indicator.dart';
+import 'package:apatie/l10n/app_localizations.dart';
+import 'package:apatie/modules/services/ui/patterns/floating_window/services_floating_window_pattern.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const configs = <_TestConfig>[
+    _TestConfig(
+      description: 'LTR locale without motion reduction',
+      locale: Locale('en'),
+      reduceMotion: false,
+    ),
+    _TestConfig(
+      description: 'RTL locale with reduced motion',
+      locale: Locale('fa'),
+      reduceMotion: true,
+    ),
+  ];
+
+  for (final config in configs) {
+    testWidgets(
+      'Services floating window exposes focus, warnings, and notifications — '
+      '${config.description}',
+      (tester) async {
+        final announcements = <String>[];
+        final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+        final previousHandler = messenger.getMockMethodCallHandler(SystemChannels.accessibility);
+        messenger.setMockMethodCallHandler(SystemChannels.accessibility, (methodCall) async {
+          if (methodCall.method == 'announce') {
+            announcements.add(methodCall.arguments as String);
+          }
+          return null;
+        });
+        addTearDown(() {
+          messenger.setMockMethodCallHandler(SystemChannels.accessibility, previousHandler);
+        });
+
+        await tester.pumpWidget(
+          _buildTestApp(
+            locale: config.locale,
+            reduceMotion: config.reduceMotion,
+            child: const ServicesFloatingWindowPattern(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final floatingContainer = tester.widget<AnimatedContainer>(
+          find.descendant(
+            of: find.bySemanticsLabel('پنجرهٔ شناور برای پایش زنده'),
+            matching: find.byType(AnimatedContainer),
+          ),
+        );
+        expect(
+          floatingContainer.duration,
+          config.reduceMotion ? Duration.zero : const Duration(milliseconds: 180),
+        );
+
+        final progressValues = tester
+            .widgetList<AppProgressIndicator>(find.byType(AppProgressIndicator))
+            .map((indicator) => indicator.value)
+            .whereType<double>()
+            .toList();
+        expect(
+          progressValues.any((value) => (value - 0.75).abs() < 0.01),
+          isTrue,
+          reason: 'Main service monitoring indicator should report 75% completion.',
+        );
+        expect(
+          progressValues.any((value) => (value - 0.45).abs() < 0.01),
+          isTrue,
+          reason: 'Floating window indicator should report 45% completion.',
+        );
+
+        await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+        await tester.pump();
+        expect(
+          announcements.any(
+            (message) => message.contains('دکمهٔ کوچک‌سازی'),
+          ),
+          isTrue,
+        );
+
+        await tester.tap(find.text('کوچک‌سازی'));
+        await tester.pumpAndSettle();
+        expect(
+          announcements,
+          contains('دکمهٔ کوچک‌سازی فشرده شد.'),
+        );
+        expect(find.text('حالت فشرده'), findsOneWidget);
+        expect(find.textContaining('پنجره در حالت فشرده'), findsOneWidget);
+
+        await tester.tap(find.text('پایان پایش'));
+        await tester.pump();
+        expect(
+          announcements,
+          contains('دکمهٔ پایان پایش فشرده شد.'),
+        );
+        await tester.pump();
+        expect(find.text('پایش زنده با موفقیت پایان یافت.'), findsOneWidget);
+
+        await tester.pump(const Duration(seconds: 4));
+        await tester.pumpAndSettle();
+        expect(find.text('پایش زنده با موفقیت پایان یافت.'), findsNothing);
+
+        await tester.tap(find.text('بازگشایی پنجره'));
+        await tester.pumpAndSettle();
+        expect(
+          announcements,
+          contains('دکمهٔ بازگشایی پنجره فشرده شد.'),
+        );
+        expect(find.text('فعال'), findsOneWidget);
+      },
+    );
+  }
+}
+
+class _TestConfig {
+  const _TestConfig({
+    required this.description,
+    required this.locale,
+    required this.reduceMotion,
+  });
+
+  final String description;
+  final Locale locale;
+  final bool reduceMotion;
+}
+
+Widget _buildTestApp({
+  required Locale locale,
+  required bool reduceMotion,
+  required Widget child,
+}) {
+  return MaterialApp(
+    debugShowCheckedModeBanner: false,
+    locale: locale,
+    supportedLocales: AppLocalizations.supportedLocales,
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    home: Builder(
+      builder: (context) {
+        final mediaQuery = MediaQuery.of(context);
+        final override = mediaQuery.copyWith(
+          disableAnimations: reduceMotion,
+          accessibleNavigation: reduceMotion,
+        );
+        return MediaQuery(
+          data: override,
+          child: Scaffold(
+            body: child,
+          ),
+        );
+      },
+    ),
+  );
+}


### PR DESCRIPTION
### Summary
- add widget tests for the appointments full-screen flow to cover focus traversal, announcements, and loading progression in LTR/RTL contexts
- cover the services floating window pattern with focus notifications, snackbar feedback, and progress indicators under reduced-motion settings
- validate the marketplace card bar and dialog patterns while documenting module interaction scenarios

### Testing
- ⚠️ `flutter test test/modules` *(fails: flutter binary is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68edd4c291548320b4aef426e7847711