### PR TITLE
Add performance integration tests and metrics reporting

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -51,6 +51,10 @@ jobs:
           flutter test integration_test/performance --machine \
             > build/performance/raw_results.json
           status=$?
+          if [ ! -f "../../scripts/parse_performance_metrics.py" ]; then
+            echo "Error: parse_performance_metrics.py not found"
+            exit 1
+          fi
           python3 ../../scripts/parse_performance_metrics.py \
             --input build/performance/raw_results.json \
             --json-output build/performance/metrics.json \

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -39,6 +39,28 @@ jobs:
         working-directory: frontend/flutter_app
         run: flutter pub get
 
-      - name: Test
+      - name: Run unit and widget tests
         working-directory: frontend/flutter_app
         run: flutter test
+
+      - name: Run performance integration tests
+        working-directory: frontend/flutter_app
+        run: |
+          set -o pipefail
+          mkdir -p build/performance
+          flutter test integration_test/performance --machine \
+            > build/performance/raw_results.json
+          status=$?
+          python3 ../../scripts/parse_performance_metrics.py \
+            --input build/performance/raw_results.json \
+            --json-output build/performance/metrics.json \
+            --markdown-output build/performance/metrics.md
+          cat build/performance/metrics.md >> "$GITHUB_STEP_SUMMARY"
+          exit $status
+
+      - name: Upload performance metrics artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-performance-metrics
+          path: frontend/flutter_app/build/performance

--- a/frontend/flutter_app/README.md
+++ b/frontend/flutter_app/README.md
@@ -22,3 +22,18 @@ The visual regression suite that protects the Apatie design system lives under [
 - Follow the [golden testing README](test/design_system/README.md) for prerequisites, local commands, and troubleshooting.
 - Run `flutter test` before submitting a change—the command exercises golden tests locally and matches what runs in CI.
 - When making intentional visual adjustments, regenerate baselines with `flutter test --update-goldens`, review the PNGs created under [`test/design_system/goldens/`](test/design_system/goldens/), and commit them with the code change.
+
+## Performance integration tests
+
+The performance suite under [`integration_test/performance/`](integration_test/performance/) measures start-up latency, scroll smoothness,
+and memory consumption. The scenarios mirror our release quality gates and emit metrics through
+`IntegrationTestWidgetsFlutterBinding.reportData` so CI can surface trends.
+
+- **Run the suite locally** with `flutter test integration_test/performance`. The command enforces the same thresholds that run in CI.
+- **Inspect metrics** by parsing the JSON log captured with `--machine` via `python scripts/parse_performance_metrics.py --input <log-file>`.
+  Add `--markdown-output` or `--json-output` flags to generate artifacts for sharing.
+- **Adjust thresholds** inside [`performance_metrics_test.dart`](integration_test/performance/performance_metrics_test.dart) when intentional
+  regressions are justified. Update the surrounding documentation in the test to explain the new baseline and include rationale in your PR.
+- **Investigate failures** by reviewing the rendered Markdown summary attached to CI (GitHub Step Summary) and the
+  `frontend-performance-metrics` artifact, which contains the raw machine-readable metrics.
+- After changing thresholds, validate locally and re-run CI to confirm the new limits capture the intended performance envelope.

--- a/frontend/flutter_app/integration_test/performance/performance_metrics_test.dart
+++ b/frontend/flutter_app/integration_test/performance/performance_metrics_test.dart
@@ -1,0 +1,243 @@
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:vm_service/vm_service.dart';
+
+import 'package:apatie/app.dart';
+
+class _InMemoryHydratedStorage implements HydratedStorage {
+  _InMemoryHydratedStorage();
+
+  final Map<String, dynamic> _store = <String, dynamic>{};
+
+  @override
+  Future<void> clear() async => _store.clear();
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+
+  @override
+  dynamic read(String key) => _store[key];
+
+  @override
+  Future<void> write(String key, dynamic value) async => _store[key] = value;
+}
+
+final IntegrationTestWidgetsFlutterBinding _binding =
+    IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+        as IntegrationTestWidgetsFlutterBinding;
+
+final Map<String, dynamic> _performanceReport = <String, dynamic>{};
+
+void _recordMetrics(String key, Map<String, Object?> metrics) {
+  _performanceReport[key] = metrics;
+  _binding.reportData = Map<String, dynamic>.from(_performanceReport);
+}
+
+double _durationToMillis(Duration duration) =>
+    duration.inMicroseconds / Duration.microsecondsPerMillisecond;
+
+double _averageMillis(Iterable<Duration> durations) {
+  final values = durations
+      .map((duration) => duration.inMicroseconds)
+      .where((value) => value > 0)
+      .toList();
+  if (values.isEmpty) {
+    return 0;
+  }
+  final total = values.reduce((a, b) => a + b);
+  return total / values.length / Duration.microsecondsPerMillisecond;
+}
+
+int _countOverBudget(Iterable<Duration> durations, Duration budget) =>
+    durations.where((duration) => duration > budget).length;
+
+double _bytesToMegabytes(num bytes) => bytes / (1024 * 1024);
+
+void main() {
+  _binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.benchmark;
+
+  setUpAll(() {
+    HydratedBloc.storage = _InMemoryHydratedStorage();
+  });
+
+  tearDownAll(() {
+    debugPrint('PERFORMANCE_METRICS:${jsonEncode(_performanceReport)}');
+  });
+
+  testWidgets('startup first frame stays under budget', (tester) async {
+    final watchResult = await _binding.watchPerformance(() async {
+      await tester.pumpWidget(App());
+      await tester.pumpAndSettle();
+    }, reportKey: 'startup_timeline');
+
+    final frameTimings = watchResult.frameTimings;
+    expect(frameTimings, isNotEmpty,
+        reason: 'Performance tracing did not capture any frames.');
+
+    final FrameTiming firstFrame = frameTimings.first;
+    final double firstFrameBuildMillis =
+        _durationToMillis(firstFrame.buildDuration);
+    final double firstFrameRasterMillis =
+        _durationToMillis(firstFrame.rasterDuration);
+
+    const double maxFirstFrameBuildMillis = 180;
+    const double maxFirstFrameRasterMillis = 180;
+
+    _recordMetrics('startup', <String, Object?>{
+      'first_frame_build_millis': firstFrameBuildMillis,
+      'first_frame_raster_millis': firstFrameRasterMillis,
+      'frame_count': frameTimings.length,
+      'timeline': watchResult.timelineSummary?.summaryJson,
+    });
+
+    expect(
+      firstFrameBuildMillis,
+      lessThanOrEqualTo(maxFirstFrameBuildMillis),
+      reason:
+          'The first frame took ${firstFrameBuildMillis.toStringAsFixed(2)}ms to build (budget $maxFirstFrameBuildMillis ms).',
+    );
+
+    expect(
+      firstFrameRasterMillis,
+      lessThanOrEqualTo(maxFirstFrameRasterMillis),
+      reason:
+          'The first frame took ${firstFrameRasterMillis.toStringAsFixed(2)}ms to rasterize (budget $maxFirstFrameRasterMillis ms).',
+    );
+  });
+
+  testWidgets('scrolling remains smooth under interaction budget',
+      (tester) async {
+    final watchResult = await _binding.watchPerformance(() async {
+      await tester.pumpWidget(App());
+      await tester.pumpAndSettle();
+
+      final Finder scrollable = find.byType(Scrollable).first;
+      await tester.fling(scrollable, const Offset(0, -600), 1000);
+      await tester.pumpAndSettle();
+      await tester.fling(scrollable, const Offset(0, 600), 1000);
+      await tester.pumpAndSettle();
+    }, reportKey: 'scroll_timeline');
+
+    final frameTimings = watchResult.frameTimings
+        .where((timing) => timing.buildDuration > Duration.zero)
+        .toList();
+    expect(frameTimings, isNotEmpty,
+        reason: 'Scroll trace did not include any frame timings.');
+
+    final averageBuildMillis =
+        _averageMillis(frameTimings.map((timing) => timing.buildDuration));
+    final averageRasterMillis =
+        _averageMillis(frameTimings.map((timing) => timing.rasterDuration));
+    final worstBuildMillis = frameTimings
+        .map((timing) => _durationToMillis(timing.buildDuration))
+        .reduce(math.max);
+    final worstRasterMillis = frameTimings
+        .map((timing) => _durationToMillis(timing.rasterDuration))
+        .reduce(math.max);
+
+    const Duration frameBudget = Duration(milliseconds: 16);
+    final int jankyFrameCount = _countOverBudget(
+      frameTimings.map((timing) => timing.buildDuration),
+      frameBudget,
+    );
+    final double jankPercentage =
+        (jankyFrameCount / frameTimings.length) * 100;
+
+    const double maxAverageBuildMillis = 24;
+    const double maxAverageRasterMillis = 28;
+    const double maxJankPercentage = 20;
+
+    _recordMetrics('scroll', <String, Object?>{
+      'average_build_millis': averageBuildMillis,
+      'average_raster_millis': averageRasterMillis,
+      'worst_build_millis': worstBuildMillis,
+      'worst_raster_millis': worstRasterMillis,
+      'janky_frame_percentage': jankPercentage,
+      'frame_count': frameTimings.length,
+    });
+
+    expect(
+      averageBuildMillis,
+      lessThanOrEqualTo(maxAverageBuildMillis),
+      reason:
+          'Average scroll build time ${averageBuildMillis.toStringAsFixed(2)}ms exceeded the $maxAverageBuildMillis ms budget.',
+    );
+    expect(
+      averageRasterMillis,
+      lessThanOrEqualTo(maxAverageRasterMillis),
+      reason:
+          'Average scroll raster time ${averageRasterMillis.toStringAsFixed(2)}ms exceeded the $maxAverageRasterMillis ms budget.',
+    );
+    expect(
+      jankPercentage,
+      lessThanOrEqualTo(maxJankPercentage),
+      reason:
+          'Scroll jank affected ${jankPercentage.toStringAsFixed(2)}% of frames (budget $maxJankPercentage%).',
+    );
+  });
+
+  testWidgets('memory footprint is within limits after warm-up',
+      (tester) async {
+    await tester.pumpWidget(App());
+    await tester.pumpAndSettle();
+
+    final VmService? vmService = await _binding.vmService;
+    expect(vmService, isNotNull,
+        reason: 'VM service was not available for memory collection.');
+    final VM vm = await vmService!.getVM();
+
+    final Iterable<IsolateRef> isolates = vm.isolates ?? const <IsolateRef>[];
+    final Map<String, Object?> isolateMetrics = <String, Object?>{};
+    int totalHeapUsageBytes = 0;
+    int totalExternalUsageBytes = 0;
+
+    for (final IsolateRef isolate in isolates) {
+      final String? isolateId = isolate.id;
+      if (isolateId == null) {
+        continue;
+      }
+      final MemoryUsage usage = await vmService.getMemoryUsage(isolateId);
+      totalHeapUsageBytes += usage.heapUsage ?? 0;
+      totalExternalUsageBytes += usage.externalUsage ?? 0;
+      isolateMetrics[isolate.name ?? isolateId] = <String, num?>{
+        'heap_usage_bytes': usage.heapUsage,
+        'external_usage_bytes': usage.externalUsage,
+      };
+    }
+
+    final double totalHeapUsageMb =
+        _bytesToMegabytes(totalHeapUsageBytes.toDouble());
+    final double totalExternalUsageMb =
+        _bytesToMegabytes(totalExternalUsageBytes.toDouble());
+
+    const double maxHeapUsageMb = 256;
+    const double maxExternalUsageMb = 128;
+
+    _recordMetrics('memory', <String, Object?>{
+      'heap_usage_mb': totalHeapUsageMb,
+      'external_usage_mb': totalExternalUsageMb,
+      'isolates': isolateMetrics,
+    });
+
+    expect(
+      totalHeapUsageMb,
+      lessThanOrEqualTo(maxHeapUsageMb),
+      reason:
+          'Total heap usage ${totalHeapUsageMb.toStringAsFixed(2)}MB exceeded the $maxHeapUsageMb MB budget.',
+    );
+    expect(
+      totalExternalUsageMb,
+      lessThanOrEqualTo(maxExternalUsageMb),
+      reason:
+          'External memory usage ${totalExternalUsageMb.toStringAsFixed(2)}MB exceeded the $maxExternalUsageMb MB budget.',
+    );
+  });
+}

--- a/frontend/flutter_app/pubspec.yaml
+++ b/frontend/flutter_app/pubspec.yaml
@@ -29,6 +29,7 @@ dev_dependencies:
   golden_toolkit: ^0.15.0
   integration_test:
     sdk: flutter
+  vm_service: ^14.2.4
 
 flutter:
   uses-material-design: true

--- a/scripts/parse_performance_metrics.py
+++ b/scripts/parse_performance_metrics.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Utility for translating Flutter integration test performance metrics.
+
+The script extracts the `binding.reportData` payload emitted by the
+performance integration tests and converts it into a concise summary that can
+be published by CI. The input is expected to be the JSON log produced by
+`flutter test --machine`, but plain-text logs containing a line that begins
+with `PERFORMANCE_METRICS:` are also supported.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Tuple
+
+_METRICS_SENTINEL = "PERFORMANCE_METRICS:"
+
+BUDGETS: Dict[str, Dict[str, float]] = {
+    "startup": {
+        "first_frame_build_millis": 180.0,
+        "first_frame_raster_millis": 180.0,
+    },
+    "scroll": {
+        "average_build_millis": 24.0,
+        "average_raster_millis": 28.0,
+        "janky_frame_percentage": 20.0,
+    },
+    "memory": {
+        "heap_usage_mb": 256.0,
+        "external_usage_mb": 128.0,
+    },
+}
+
+
+@dataclass
+class MetricStatus:
+    """Represents a single metric and its evaluation."""
+
+    name: str
+    value: float | None
+    budget: float | None
+
+    @property
+    def passed(self) -> bool | None:
+        if self.value is None or self.budget is None:
+            return None
+        return self.value <= self.budget
+
+    def to_row(self) -> Tuple[str, str, str, str]:
+        formatted_value = "n/a" if self.value is None else f"{self.value:.2f}"
+        formatted_budget = "n/a" if self.budget is None else f"{self.budget:.2f}"
+        if self.passed is None:
+            status = "UNKNOWN"
+            emoji = "⚪"
+        elif self.passed:
+            status = "PASS"
+            emoji = "✅"
+        else:
+            status = "FAIL"
+            emoji = "❌"
+        return (self.name, formatted_value, formatted_budget, f"{emoji} {status}")
+
+
+def _load_lines(path: Path) -> Iterable[str]:
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            yield line.rstrip("\n")
+
+
+def _try_decode_json(text: str) -> Dict[str, Any] | None:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(data, dict):
+        return data
+    return None
+
+
+def _extract_metrics_from_message(message: str) -> Dict[str, Any] | None:
+    sentinel_index = message.find(_METRICS_SENTINEL)
+    if sentinel_index == -1:
+        return None
+    payload = message[sentinel_index + len(_METRICS_SENTINEL) :].strip()
+    if not payload:
+        return None
+    metrics = _try_decode_json(payload)
+    if metrics is not None:
+        return metrics
+    # Some CI logs escape the JSON payload – attempt a secondary decode.
+    try:
+        unescaped = bytes(payload, "utf-8").decode("unicode_escape")
+    except UnicodeDecodeError:
+        return None
+    return _try_decode_json(unescaped)
+
+
+def load_metrics(path: Path) -> Dict[str, Any]:
+    """Parse the Flutter test log and extract the performance metrics."""
+
+    for raw_line in _load_lines(path):
+        metrics = _extract_metrics_from_message(raw_line)
+        if metrics is not None:
+            return metrics
+        parsed_line = _try_decode_json(raw_line)
+        if not parsed_line:
+            continue
+        message = parsed_line.get("message")
+        if isinstance(message, str):
+            metrics = _extract_metrics_from_message(message)
+            if metrics is not None:
+                return metrics
+    raise RuntimeError(
+        "No performance metrics were found. Ensure the integration tests "
+        "printed a PERFORMANCE_METRICS line and the log was captured correctly.",
+    )
+
+
+def build_status(metrics: Dict[str, Any]) -> Dict[str, Tuple[str, ...]]:
+    summary: Dict[str, Tuple[str, ...]] = {}
+    for category, category_metrics in metrics.items():
+        category_budget = BUDGETS.get(category, {})
+        rows = []
+        if isinstance(category_metrics, dict):
+            for metric_name, value in category_metrics.items():
+                if isinstance(value, (int, float)):
+                    metric_value: float | None = float(value)
+                else:
+                    metric_value = None
+                budget_value = category_budget.get(metric_name)
+                rows.append(
+                    MetricStatus(metric_name, metric_value, budget_value).to_row()
+                )
+        summary[category] = tuple(rows)
+    return summary
+
+
+def emit_stdout(summary: Dict[str, Tuple[str, ...]]) -> None:
+    print("Performance metric summary:")
+    for category, rows in summary.items():
+        print(f"\n[{category}]")
+        if not rows:
+            print("  (no numeric metrics reported)")
+            continue
+        for name, value, budget, status in rows:
+            print(f"  - {name}: {value} (budget {budget}) → {status}")
+
+
+def emit_markdown(summary: Dict[str, Tuple[str, ...]], destination: Path) -> None:
+    lines = ["# Performance metrics", "", "| Category | Metric | Value | Budget | Status |", "| --- | --- | --- | --- | --- |"]
+    for category, rows in summary.items():
+        if not rows:
+            lines.append(f"| {category} | _no numeric metrics_ | n/a | n/a | ⚪ UNKNOWN |")
+            continue
+        first = True
+        for name, value, budget, status in rows:
+            category_cell = category if first else ""
+            first = False
+            lines.append(f"| {category_cell} | {name} | {value} | {budget} | {status} |")
+    destination.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def emit_json(metrics: Dict[str, Any], destination: Path) -> None:
+    destination.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="Path to the raw Flutter test output")
+    parser.add_argument(
+        "--markdown-output",
+        type=Path,
+        help="Optional path to write a Markdown summary table",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Optional path to write the parsed metrics as JSON",
+    )
+    return parser.parse_args(list(argv))
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    metrics = load_metrics(args.input)
+    summary = build_status(metrics)
+    emit_stdout(summary)
+    if args.markdown_output:
+        emit_markdown(summary, args.markdown_output)
+    if args.json_output:
+        emit_json(metrics, args.json_output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add integration tests that collect start-up, scroll, and memory metrics via `IntegrationTestWidgetsFlutterBinding`
- introduce a parser script that turns the report data into JSON/Markdown for CI consumption
- update the frontend CI workflow to run the performance suite, summarize the results, and upload artifacts
- document how to execute the suite locally and adjust performance thresholds

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68eded60def08320a99cd20770fda767