### PR TITLE
Add Vercal configuration for Flutter frontend

### DIFF
--- a/Vercal.json
+++ b/Vercal.json
@@ -1,10 +1,10 @@
-{
-  "version": 2,
+{ "version": 2,
+  "root": "frontend/flutter_app",
   "projectSettings": {
     "framework": "other"
   },
-  "installCommand": "cd frontend/flutter_app && flutter pub get",
-  "buildCommand": "cd frontend/flutter_app && flutter build web --release",
-  "outputDirectory": "frontend/flutter_app/build/web",
+  "installCommand": "flutter pub get",
+  "buildCommand": "flutter build web --release",
+  "outputDirectory": "build/web",
   "cleanUrls": true
 }

--- a/Vercal.json
+++ b/Vercal.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "projectSettings": {
+    "framework": "other"
+  },
+  "installCommand": "cd frontend/flutter_app && flutter pub get",
+  "buildCommand": "cd frontend/flutter_app && flutter build web --release",
+  "outputDirectory": "frontend/flutter_app/build/web",
+  "cleanUrls": true
+}


### PR DESCRIPTION
## Summary
- add a Vercal.json deployment configuration at the repository root
- configure install and build commands to target the Flutter web frontend in `frontend/flutter_app`
- specify the build output directory and enable clean URLs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee75260aa48320a561c4fe6979f38b